### PR TITLE
Build dart-tools .whls for different environments, needed because of regex._regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - [Setup](#setup)
 - [Using the CLI](#using-the-cli)
 - [Using the Python Library](#using-the-python-library)
+- [Using the Python Library in AWS Lambda Functions](#using-the-python-library-in-aws-lambda-functions)
 - [Advanced Usage](#advanced-usage)
 - [Help and Resources](#help-and-resources)
 
@@ -71,6 +72,43 @@ new_task = create_task(
 update_task(new_task.duid, status_title="Done")
 ```
 
+## Using the Python Library in AWS Lambda Functions
+
+To use the `dart-tools` Python library in an AWS Lambda function, you need to package the library with your Lambda deployment package (see more details at [Working with .zip file archives for Python Lambda functions](https://docs.aws.amazon.com/lambda/latest/dg/python-package.html)). Follow these steps:
+
+1. Navigate to the directory containing your `lambda_function.py` source file. In this example, the directory is named `my_function`.
+
+  ```bash
+  cd my_function
+  ```
+
+2. Create a Deployment Package
+
+  Use Docker to create a deployment package that includes the `dart-tools` library. Run the following commands in your terminal, ensuring that the `RUNTIME_PYTHON_VERSION` and `RUNTIME_ARCHITECTURE` environment variables match the runtime settings of your Lambda function:
+
+
+  ```bash
+  export RUNTIME_PYTHON_VERSION=3.12
+  export RUNTIME_ARCHITECTURE=x86_64
+  docker run --rm --volume ${PWD}:/app --entrypoint /bin/bash public.ecr.aws/lambda/python:${RUNTIME_PYTHON_VERSION}-${RUNTIME_ARCHITECTURE} -c "pip install --target /app/package dart-tools"
+  ```
+
+  This command installs the `dart-tools` library into a directory named `package` in your current working directory.
+
+3. Zip the contents of the `package` directory along with your `lambda_function.py`
+
+  ```bash
+  cd package
+  zip -r ../my_deployment_package.zip .
+  cd ..
+  zip -r my_deployment_package.zip lambda_function.py
+  ```
+
+4. Deploy the Lambda function
+
+  Upload the `my_deployment_package.zip` file to AWS Lambda using the AWS Management Console or the AWS CLI.
+
+By following these steps, you can use the `dart-tools` Python library within your AWS Lambda functions.
 
 ## Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ To use the `dart-tools` Python library in an AWS Lambda function, you need to pa
 
   Use Docker to create a deployment package that includes the `dart-tools` library. Run the following commands in your terminal, ensuring that the `RUNTIME_PYTHON_VERSION` and `RUNTIME_ARCHITECTURE` environment variables match the runtime settings of your Lambda function:
 
-
   ```bash
   export RUNTIME_PYTHON_VERSION=3.12
   export RUNTIME_ARCHITECTURE=x86_64

--- a/admin/README.md
+++ b/admin/README.md
@@ -15,7 +15,8 @@
 
 ## Sync API
 
-1. Run `admin/make-openapi.sh`
+1. Run `pip install openapi-python-client` as needed
+2. Run `admin/make-api.sh`
 
 
 ## Deploy setup

--- a/dart/__init__.py
+++ b/dart/__init__.py
@@ -1,3 +1,5 @@
+# Required for type hinting compatibility when using Python 3.9
+from __future__ import annotations
 from .generated.models import *
 from .dart import (
     Dart,

--- a/dart/dart.py
+++ b/dart/dart.py
@@ -3,6 +3,8 @@
 
 """A CLI to interact with the Dart web app."""
 
+# Required for type hinting compatibility when using Python 3.9
+from __future__ import annotations
 from argparse import ArgumentParser
 from functools import wraps
 import json

--- a/dart/generated/api/attachments/attachments_list.py
+++ b/dart/generated/api/attachments/attachments_list.py
@@ -34,7 +34,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedAttachmentList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedAttachmentList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/attachments/attachments_list.py
+++ b/dart/generated/api/attachments/attachments_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -13,8 +13,8 @@ def _get_kwargs(
     *,
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["limit"] = limit
 
@@ -22,7 +22,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/attachments",
         "params": params,

--- a/dart/generated/api/comments/comments_list.py
+++ b/dart/generated/api/comments/comments_list.py
@@ -1,6 +1,6 @@
 import datetime
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -21,8 +21,8 @@ def _get_kwargs(
     task_duid: Union[Unset, str] = UNSET,
     text: Union[Unset, str] = UNSET,
     title: Union[Unset, str] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["author"] = author
 
@@ -47,7 +47,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/comments",
         "params": params,

--- a/dart/generated/api/comments/comments_list.py
+++ b/dart/generated/api/comments/comments_list.py
@@ -59,7 +59,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedCommentList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedCommentList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/dartboards/dartboards_list.py
+++ b/dart/generated/api/dartboards/dartboards_list.py
@@ -64,7 +64,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedDartboardList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedDartboardList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/dartboards/dartboards_list.py
+++ b/dart/generated/api/dartboards/dartboards_list.py
@@ -1,6 +1,6 @@
 import datetime
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -21,8 +21,8 @@ def _get_kwargs(
     space_duid: Union[Unset, str] = UNSET,
     started_at: Union[Unset, datetime.date] = UNSET,
     title: Union[Unset, str] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     json_finished_at: Union[Unset, str] = UNSET
     if not isinstance(finished_at, Unset):
@@ -52,7 +52,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/dartboards",
         "params": params,

--- a/dart/generated/api/dashboards/dashboards_list.py
+++ b/dart/generated/api/dashboards/dashboards_list.py
@@ -37,7 +37,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedDashboardList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedDashboardList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/dashboards/dashboards_list.py
+++ b/dart/generated/api/dashboards/dashboards_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -14,8 +14,8 @@ def _get_kwargs(
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
     title: Union[Unset, str] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["limit"] = limit
 
@@ -25,7 +25,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/dashboards",
         "params": params,

--- a/dart/generated/api/docs/docs_list.py
+++ b/dart/generated/api/docs/docs_list.py
@@ -67,7 +67,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedDocList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedDocList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/docs/docs_list.py
+++ b/dart/generated/api/docs/docs_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -24,8 +24,8 @@ def _get_kwargs(
     subscriber_duid: Union[Unset, str] = UNSET,
     text: Union[Unset, str] = UNSET,
     title: Union[Unset, str] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["editor"] = editor
 
@@ -55,7 +55,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/docs",
         "params": params,

--- a/dart/generated/api/folders/folders_list.py
+++ b/dart/generated/api/folders/folders_list.py
@@ -51,7 +51,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedFolderList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedFolderList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/folders/folders_list.py
+++ b/dart/generated/api/folders/folders_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -18,8 +18,8 @@ def _get_kwargs(
     space: Union[Unset, str] = UNSET,
     space_duid: Union[Unset, str] = UNSET,
     title: Union[Unset, str] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     json_kind: Union[Unset, str] = UNSET
     if not isinstance(kind, Unset):
@@ -39,7 +39,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/folders",
         "params": params,

--- a/dart/generated/api/form_fields/form_fields_list.py
+++ b/dart/generated/api/form_fields/form_fields_list.py
@@ -34,7 +34,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedFormFieldList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedFormFieldList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/form_fields/form_fields_list.py
+++ b/dart/generated/api/form_fields/form_fields_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -13,8 +13,8 @@ def _get_kwargs(
     *,
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["limit"] = limit
 
@@ -22,7 +22,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/form-fields",
         "params": params,

--- a/dart/generated/api/forms/forms_list.py
+++ b/dart/generated/api/forms/forms_list.py
@@ -34,7 +34,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedFormList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedFormList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/forms/forms_list.py
+++ b/dart/generated/api/forms/forms_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -13,8 +13,8 @@ def _get_kwargs(
     *,
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["limit"] = limit
 
@@ -22,7 +22,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/forms",
         "params": params,

--- a/dart/generated/api/layouts/layouts_list.py
+++ b/dart/generated/api/layouts/layouts_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -13,8 +13,8 @@ def _get_kwargs(
     *,
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["limit"] = limit
 
@@ -22,7 +22,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/layouts",
         "params": params,

--- a/dart/generated/api/layouts/layouts_list.py
+++ b/dart/generated/api/layouts/layouts_list.py
@@ -34,7 +34,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedLayoutList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedLayoutList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/links/links_list.py
+++ b/dart/generated/api/links/links_list.py
@@ -34,7 +34,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedTaskLinkList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedTaskLinkList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/links/links_list.py
+++ b/dart/generated/api/links/links_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -13,8 +13,8 @@ def _get_kwargs(
     *,
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["limit"] = limit
 
@@ -22,7 +22,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/links",
         "params": params,

--- a/dart/generated/api/options/options_list.py
+++ b/dart/generated/api/options/options_list.py
@@ -46,7 +46,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedOptionList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedOptionList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/options/options_list.py
+++ b/dart/generated/api/options/options_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -17,8 +17,8 @@ def _get_kwargs(
     property_: Union[Unset, str] = UNSET,
     property_duid: Union[Unset, str] = UNSET,
     title: Union[Unset, str] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["default_only"] = default_only
 
@@ -34,7 +34,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/options",
         "params": params,

--- a/dart/generated/api/properties/properties_list.py
+++ b/dart/generated/api/properties/properties_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -16,8 +16,8 @@ def _get_kwargs(
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
     title: Union[Unset, str] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     json_kind: Union[Unset, str] = UNSET
     if not isinstance(kind, Unset):
@@ -33,7 +33,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/properties",
         "params": params,

--- a/dart/generated/api/properties/properties_list.py
+++ b/dart/generated/api/properties/properties_list.py
@@ -45,7 +45,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedPropertyList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedPropertyList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/reactions/reactions_list.py
+++ b/dart/generated/api/reactions/reactions_list.py
@@ -34,7 +34,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedCommentReactionList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedCommentReactionList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/reactions/reactions_list.py
+++ b/dart/generated/api/reactions/reactions_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -13,8 +13,8 @@ def _get_kwargs(
     *,
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["limit"] = limit
 
@@ -22,7 +22,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/reactions",
         "params": params,

--- a/dart/generated/api/relationship_kinds/relationship_kinds_list.py
+++ b/dart/generated/api/relationship_kinds/relationship_kinds_list.py
@@ -34,7 +34,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedRelationshipKindList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedRelationshipKindList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/relationship_kinds/relationship_kinds_list.py
+++ b/dart/generated/api/relationship_kinds/relationship_kinds_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -13,8 +13,8 @@ def _get_kwargs(
     *,
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["limit"] = limit
 
@@ -22,7 +22,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/relationship-kinds",
         "params": params,

--- a/dart/generated/api/relationships/relationships_list.py
+++ b/dart/generated/api/relationships/relationships_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -13,8 +13,8 @@ def _get_kwargs(
     *,
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["limit"] = limit
 
@@ -22,7 +22,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/relationships",
         "params": params,

--- a/dart/generated/api/relationships/relationships_list.py
+++ b/dart/generated/api/relationships/relationships_list.py
@@ -34,7 +34,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedRelationshipList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedRelationshipList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/spaces/spaces_list.py
+++ b/dart/generated/api/spaces/spaces_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -16,8 +16,8 @@ def _get_kwargs(
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
     title: Union[Unset, str] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["abrev"] = abrev
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/spaces",
         "params": params,

--- a/dart/generated/api/spaces/spaces_list.py
+++ b/dart/generated/api/spaces/spaces_list.py
@@ -43,7 +43,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedSpaceList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedSpaceList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/statuses/statuses_list.py
+++ b/dart/generated/api/statuses/statuses_list.py
@@ -54,7 +54,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedStatusList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedStatusList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/statuses/statuses_list.py
+++ b/dart/generated/api/statuses/statuses_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -19,8 +19,8 @@ def _get_kwargs(
     property_: Union[Unset, str] = UNSET,
     property_duid: Union[Unset, str] = UNSET,
     title: Union[Unset, str] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["default_only"] = default_only
 
@@ -42,7 +42,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/statuses",
         "params": params,

--- a/dart/generated/api/task_doc_relationships/task_doc_relationships_list.py
+++ b/dart/generated/api/task_doc_relationships/task_doc_relationships_list.py
@@ -34,7 +34,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedTaskDocRelationshipList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedTaskDocRelationshipList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/task_doc_relationships/task_doc_relationships_list.py
+++ b/dart/generated/api/task_doc_relationships/task_doc_relationships_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -13,8 +13,8 @@ def _get_kwargs(
     *,
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["limit"] = limit
 
@@ -22,7 +22,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/task-doc-relationships",
         "params": params,

--- a/dart/generated/api/task_kinds/task_kinds_list.py
+++ b/dart/generated/api/task_kinds/task_kinds_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -16,8 +16,8 @@ def _get_kwargs(
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
     title: Union[Unset, str] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     json_kind: Union[Unset, str] = UNSET
     if not isinstance(kind, Unset):
@@ -33,7 +33,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/task-kinds",
         "params": params,

--- a/dart/generated/api/task_kinds/task_kinds_list.py
+++ b/dart/generated/api/task_kinds/task_kinds_list.py
@@ -45,7 +45,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedTaskKindList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedTaskKindList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/tasks/tasks_list.py
+++ b/dart/generated/api/tasks/tasks_list.py
@@ -95,7 +95,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedTaskList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedTaskList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/tasks/tasks_list.py
+++ b/dart/generated/api/tasks/tasks_list.py
@@ -1,6 +1,6 @@
 import datetime
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -32,8 +32,8 @@ def _get_kwargs(
     subscriber_duid: Union[Unset, str] = UNSET,
     tag: Union[Unset, str] = UNSET,
     title: Union[Unset, str] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["assignee"] = assignee
 
@@ -83,7 +83,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/tasks",
         "params": params,

--- a/dart/generated/api/tenants/tenants_list.py
+++ b/dart/generated/api/tenants/tenants_list.py
@@ -34,7 +34,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedTenantList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedTenantList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/tenants/tenants_list.py
+++ b/dart/generated/api/tenants/tenants_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -13,8 +13,8 @@ def _get_kwargs(
     *,
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["limit"] = limit
 
@@ -22,7 +22,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/tenants",
         "params": params,

--- a/dart/generated/api/transactions/transactions_create.py
+++ b/dart/generated/api/transactions/transactions_create.py
@@ -37,11 +37,11 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Union[ResponseBody, ValidationErrorResponse]]:
-    if response.status_code == HTTPStatus.CREATED:
+    if response.status_code == 201:
         response_201 = ResponseBody.from_dict(response.json())
 
         return response_201
-    if response.status_code == HTTPStatus.BAD_REQUEST:
+    if response.status_code == 400:
         response_400 = ValidationErrorResponse.from_dict(response.json())
 
         return response_400

--- a/dart/generated/api/transactions/transactions_create.py
+++ b/dart/generated/api/transactions/transactions_create.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -15,12 +15,12 @@ def _get_kwargs(
     *,
     body: RequestBody,
     x_csrftoken: Union[Unset, str] = UNSET,
-) -> Dict[str, Any]:
-    headers: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
     if not isinstance(x_csrftoken, Unset):
         headers["x-csrftoken"] = x_csrftoken
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "post",
         "url": "/api/v0/transactions/create",
     }

--- a/dart/generated/api/user_dartboard_layouts/user_dartboard_layouts_list.py
+++ b/dart/generated/api/user_dartboard_layouts/user_dartboard_layouts_list.py
@@ -34,7 +34,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedUserDartboardLayoutList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedUserDartboardLayoutList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/user_dartboard_layouts/user_dartboard_layouts_list.py
+++ b/dart/generated/api/user_dartboard_layouts/user_dartboard_layouts_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -13,8 +13,8 @@ def _get_kwargs(
     *,
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["limit"] = limit
 
@@ -22,7 +22,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/user-dartboard-layouts",
         "params": params,

--- a/dart/generated/api/user_data/user_data_entity_retrieve.py
+++ b/dart/generated/api/user_data/user_data_entity_retrieve.py
@@ -77,7 +77,7 @@ def _parse_response(
         "Webhook",
     ]
 ]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
 
         def _parse_response_200(
             data: object,

--- a/dart/generated/api/user_data/user_data_entity_retrieve.py
+++ b/dart/generated/api/user_data/user_data_entity_retrieve.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -37,8 +37,8 @@ from ...types import Response
 def _get_kwargs(
     entity_kind: UserDataEntityRetrieveEntityKind,
     entity_duid: str,
-) -> Dict[str, Any]:
-    _kwargs: Dict[str, Any] = {
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": f"/api/v0/{entity_kind}/{entity_duid}",
     }

--- a/dart/generated/api/users/users_list.py
+++ b/dart/generated/api/users/users_list.py
@@ -43,7 +43,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedUserList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedUserList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/users/users_list.py
+++ b/dart/generated/api/users/users_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -16,8 +16,8 @@ def _get_kwargs(
     name: Union[Unset, str] = UNSET,
     offset: Union[Unset, int] = UNSET,
     role: Union[Unset, str] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["email"] = email
 
@@ -31,7 +31,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/users",
         "params": params,

--- a/dart/generated/api/views/views_list.py
+++ b/dart/generated/api/views/views_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -14,8 +14,8 @@ def _get_kwargs(
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
     title: Union[Unset, str] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["limit"] = limit
 
@@ -25,7 +25,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/views",
         "params": params,

--- a/dart/generated/api/views/views_list.py
+++ b/dart/generated/api/views/views_list.py
@@ -37,7 +37,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedViewList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedViewList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/webhooks/webhooks_list.py
+++ b/dart/generated/api/webhooks/webhooks_list.py
@@ -34,7 +34,7 @@ def _get_kwargs(
 def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[PaginatedWebhookList]:
-    if response.status_code == HTTPStatus.OK:
+    if response.status_code == 200:
         response_200 = PaginatedWebhookList.from_dict(response.json())
 
         return response_200

--- a/dart/generated/api/webhooks/webhooks_list.py
+++ b/dart/generated/api/webhooks/webhooks_list.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -13,8 +13,8 @@ def _get_kwargs(
     *,
     limit: Union[Unset, int] = UNSET,
     offset: Union[Unset, int] = UNSET,
-) -> Dict[str, Any]:
-    params: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
 
     params["limit"] = limit
 
@@ -22,7 +22,7 @@ def _get_kwargs(
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
-    _kwargs: Dict[str, Any] = {
+    _kwargs: dict[str, Any] = {
         "method": "get",
         "url": "/api/v0/webhooks",
         "params": params,

--- a/dart/generated/client.py
+++ b/dart/generated/client.py
@@ -70,7 +70,7 @@ class Client:
         return evolve(self, timeout=timeout)
 
     def set_httpx_client(self, client: httpx.Client) -> "Client":
-        """Manually the underlying httpx.Client
+        """Manually set the underlying httpx.Client
 
         **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
         """
@@ -204,7 +204,7 @@ class AuthenticatedClient:
         return evolve(self, timeout=timeout)
 
     def set_httpx_client(self, client: httpx.Client) -> "AuthenticatedClient":
-        """Manually the underlying httpx.Client
+        """Manually set the underlying httpx.Client
 
         **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
         """

--- a/dart/generated/client.py
+++ b/dart/generated/client.py
@@ -1,5 +1,5 @@
 import ssl
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 from attrs import define, evolve, field
@@ -36,16 +36,16 @@ class Client:
 
     raise_on_unexpected_status: bool = field(default=False, kw_only=True)
     _base_url: str = field(alias="base_url")
-    _cookies: Dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
-    _headers: Dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
     _timeout: Optional[httpx.Timeout] = field(default=None, kw_only=True, alias="timeout")
     _verify_ssl: Union[str, bool, ssl.SSLContext] = field(default=True, kw_only=True, alias="verify_ssl")
     _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
-    _httpx_args: Dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
     _client: Optional[httpx.Client] = field(default=None, init=False)
     _async_client: Optional[httpx.AsyncClient] = field(default=None, init=False)
 
-    def with_headers(self, headers: Dict[str, str]) -> "Client":
+    def with_headers(self, headers: dict[str, str]) -> "Client":
         """Get a new client matching this one with additional headers"""
         if self._client is not None:
             self._client.headers.update(headers)
@@ -53,7 +53,7 @@ class Client:
             self._async_client.headers.update(headers)
         return evolve(self, headers={**self._headers, **headers})
 
-    def with_cookies(self, cookies: Dict[str, str]) -> "Client":
+    def with_cookies(self, cookies: dict[str, str]) -> "Client":
         """Get a new client matching this one with additional cookies"""
         if self._client is not None:
             self._client.cookies.update(cookies)
@@ -166,12 +166,12 @@ class AuthenticatedClient:
 
     raise_on_unexpected_status: bool = field(default=False, kw_only=True)
     _base_url: str = field(alias="base_url")
-    _cookies: Dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
-    _headers: Dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
     _timeout: Optional[httpx.Timeout] = field(default=None, kw_only=True, alias="timeout")
     _verify_ssl: Union[str, bool, ssl.SSLContext] = field(default=True, kw_only=True, alias="verify_ssl")
     _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
-    _httpx_args: Dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
     _client: Optional[httpx.Client] = field(default=None, init=False)
     _async_client: Optional[httpx.AsyncClient] = field(default=None, init=False)
 
@@ -179,7 +179,7 @@ class AuthenticatedClient:
     prefix: str = "Bearer"
     auth_header_name: str = "Authorization"
 
-    def with_headers(self, headers: Dict[str, str]) -> "AuthenticatedClient":
+    def with_headers(self, headers: dict[str, str]) -> "AuthenticatedClient":
         """Get a new client matching this one with additional headers"""
         if self._client is not None:
             self._client.headers.update(headers)
@@ -187,7 +187,7 @@ class AuthenticatedClient:
             self._async_client.headers.update(headers)
         return evolve(self, headers={**self._headers, **headers})
 
-    def with_cookies(self, cookies: Dict[str, str]) -> "AuthenticatedClient":
+    def with_cookies(self, cookies: dict[str, str]) -> "AuthenticatedClient":
         """Get a new client matching this one with additional cookies"""
         if self._client is not None:
             self._client.cookies.update(cookies)

--- a/dart/generated/models/__init__.py
+++ b/dart/generated/models/__init__.py
@@ -10,6 +10,7 @@ from .brainstorm_state import BrainstormState
 from .brainstorm_update import BrainstormUpdate
 from .burn_up_chart_adtl import BurnUpChartAdtl
 from .chart import Chart
+from .chart_aggregation import ChartAggregation
 from .chart_type import ChartType
 from .comment import Comment
 from .comment_create import CommentCreate
@@ -71,7 +72,6 @@ from .notification_update import NotificationUpdate
 from .notion_integration import NotionIntegration
 from .notion_integration_tenant_extension_status import NotionIntegrationTenantExtensionStatus
 from .number_chart_adtl import NumberChartAdtl
-from .number_chart_aggregation import NumberChartAggregation
 from .operation import Operation
 from .operation_kind import OperationKind
 from .operation_model_kind import OperationModelKind
@@ -195,6 +195,7 @@ __all__ = (
     "BrainstormUpdate",
     "BurnUpChartAdtl",
     "Chart",
+    "ChartAggregation",
     "ChartType",
     "Comment",
     "CommentCreate",
@@ -256,7 +257,6 @@ __all__ = (
     "NotionIntegration",
     "NotionIntegrationTenantExtensionStatus",
     "NumberChartAdtl",
-    "NumberChartAggregation",
     "Operation",
     "OperationKind",
     "OperationModelKind",

--- a/dart/generated/models/attachment.py
+++ b/dart/generated/models/attachment.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -26,9 +26,9 @@ class Attachment:
     file_url: str
     color_hex: str
     recommendation_duid: Union[None, str]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         order = self.order
@@ -44,7 +44,7 @@ class Attachment:
         recommendation_duid: Union[None, str]
         recommendation_duid = self.recommendation_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -61,7 +61,7 @@ class Attachment:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -96,7 +96,7 @@ class Attachment:
         return attachment
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/attachment_create.py
+++ b/dart/generated/models/attachment_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -28,9 +28,9 @@ class AttachmentCreate:
     file_path: str
     color_hex: Union[Unset, str] = UNSET
     recommendation_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         order = self.order
@@ -49,7 +49,7 @@ class AttachmentCreate:
         else:
             recommendation_duid = self.recommendation_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -68,7 +68,7 @@ class AttachmentCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -105,7 +105,7 @@ class AttachmentCreate:
         return attachment_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/attachment_update.py
+++ b/dart/generated/models/attachment_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -28,9 +28,9 @@ class AttachmentUpdate:
     file_path: Union[Unset, str] = UNSET
     color_hex: Union[Unset, str] = UNSET
     recommendation_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         order = self.order
@@ -49,7 +49,7 @@ class AttachmentUpdate:
         else:
             recommendation_duid = self.recommendation_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -72,7 +72,7 @@ class AttachmentUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -109,7 +109,7 @@ class AttachmentUpdate:
         return attachment_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/bar_chart_adtl.py
+++ b/dart/generated/models/bar_chart_adtl.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -16,15 +16,15 @@ class BarChartAdtl:
 
     x_property_duid: str
     stack_property_duid: Union[None, str]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         x_property_duid = self.x_property_duid
 
         stack_property_duid: Union[None, str]
         stack_property_duid = self.stack_property_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -36,7 +36,7 @@ class BarChartAdtl:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         x_property_duid = d.pop("xPropertyDuid")
 
@@ -56,7 +56,7 @@ class BarChartAdtl:
         return bar_chart_adtl
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/brainstorm.py
+++ b/dart/generated/models/brainstorm.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -25,7 +25,7 @@ class Brainstorm:
             * `Paused` - PAUSED
             * `Stopped` - STOPPED
         after_start_ms (int):
-        created_tasks_duids (List[str]):
+        created_tasks_duids (list[str]):
         updated_by_client_duid (Union[None, Unset, str]):
     """
 
@@ -37,11 +37,11 @@ class Brainstorm:
     started_at: datetime.datetime
     state: BrainstormState
     after_start_ms: int
-    created_tasks_duids: List[str]
+    created_tasks_duids: list[str]
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         dartboard_duid = self.dartboard_duid
@@ -66,7 +66,7 @@ class Brainstorm:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -87,7 +87,7 @@ class Brainstorm:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -105,7 +105,7 @@ class Brainstorm:
 
         after_start_ms = d.pop("afterStartMs")
 
-        created_tasks_duids = cast(List[str], d.pop("createdTasksDuids"))
+        created_tasks_duids = cast(list[str], d.pop("createdTasksDuids"))
 
         def _parse_updated_by_client_duid(data: object) -> Union[None, Unset, str]:
             if data is None:
@@ -133,7 +133,7 @@ class Brainstorm:
         return brainstorm
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/brainstorm_create.py
+++ b/dart/generated/models/brainstorm_create.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -25,7 +25,7 @@ class BrainstormCreate:
             * `Stopped` - STOPPED
         total_session_ms (Union[Unset, int]):
         after_start_ms (Union[Unset, int]):
-        created_tasks_duids (Union[Unset, List[str]]):
+        created_tasks_duids (Union[Unset, list[str]]):
     """
 
     duid: str
@@ -36,10 +36,10 @@ class BrainstormCreate:
     state: BrainstormState
     total_session_ms: Union[Unset, int] = UNSET
     after_start_ms: Union[Unset, int] = UNSET
-    created_tasks_duids: Union[Unset, List[str]] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    created_tasks_duids: Union[Unset, list[str]] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         dartboard_duid = self.dartboard_duid
@@ -56,11 +56,11 @@ class BrainstormCreate:
 
         after_start_ms = self.after_start_ms
 
-        created_tasks_duids: Union[Unset, List[str]] = UNSET
+        created_tasks_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.created_tasks_duids, Unset):
             created_tasks_duids = self.created_tasks_duids
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -82,7 +82,7 @@ class BrainstormCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -100,7 +100,7 @@ class BrainstormCreate:
 
         after_start_ms = d.pop("afterStartMs", UNSET)
 
-        created_tasks_duids = cast(List[str], d.pop("createdTasksDuids", UNSET))
+        created_tasks_duids = cast(list[str], d.pop("createdTasksDuids", UNSET))
 
         brainstorm_create = cls(
             duid=duid,
@@ -118,7 +118,7 @@ class BrainstormCreate:
         return brainstorm_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/brainstorm_update.py
+++ b/dart/generated/models/brainstorm_update.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -25,7 +25,7 @@ class BrainstormUpdate:
             * `Paused` - PAUSED
             * `Stopped` - STOPPED
         after_start_ms (Union[Unset, int]):
-        created_tasks_duids (Union[Unset, List[str]]):
+        created_tasks_duids (Union[Unset, list[str]]):
     """
 
     duid: str
@@ -36,10 +36,10 @@ class BrainstormUpdate:
     started_at: Union[Unset, datetime.datetime] = UNSET
     state: Union[Unset, BrainstormState] = UNSET
     after_start_ms: Union[Unset, int] = UNSET
-    created_tasks_duids: Union[Unset, List[str]] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    created_tasks_duids: Union[Unset, list[str]] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         dartboard_duid = self.dartboard_duid
@@ -60,11 +60,11 @@ class BrainstormUpdate:
 
         after_start_ms = self.after_start_ms
 
-        created_tasks_duids: Union[Unset, List[str]] = UNSET
+        created_tasks_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.created_tasks_duids, Unset):
             created_tasks_duids = self.created_tasks_duids
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -91,7 +91,7 @@ class BrainstormUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -119,7 +119,7 @@ class BrainstormUpdate:
 
         after_start_ms = d.pop("afterStartMs", UNSET)
 
-        created_tasks_duids = cast(List[str], d.pop("createdTasksDuids", UNSET))
+        created_tasks_duids = cast(list[str], d.pop("createdTasksDuids", UNSET))
 
         brainstorm_update = cls(
             duid=duid,
@@ -137,7 +137,7 @@ class BrainstormUpdate:
         return brainstorm_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/burn_up_chart_adtl.py
+++ b/dart/generated/models/burn_up_chart_adtl.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -18,9 +18,9 @@ class BurnUpChartAdtl:
 
     start_date: Union[None, datetime.date]
     end_date: Union[None, datetime.date]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         start_date: Union[None, str]
         if isinstance(self.start_date, datetime.date):
             start_date = self.start_date.isoformat()
@@ -33,7 +33,7 @@ class BurnUpChartAdtl:
         else:
             end_date = self.end_date
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -45,7 +45,7 @@ class BurnUpChartAdtl:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
 
         def _parse_start_date(data: object) -> Union[None, datetime.date]:
@@ -87,7 +87,7 @@ class BurnUpChartAdtl:
         return burn_up_chart_adtl
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/chart.py
+++ b/dart/generated/models/chart.py
@@ -23,11 +23,12 @@ class Chart:
     Attributes:
         duid (str):
         type (ChartType): * `bar` - BAR
-            * `burnup` - BURN_UP
+            * `burn-up` - BURN_UP
             * `line` - LINE
             * `number` - NUMBER
             * `pie` - PIE
             * `table` - TABLE
+            * `text` - TEXT_BLOCK
         title (str):
         x (int):
         y (int):

--- a/dart/generated/models/chart.py
+++ b/dart/generated/models/chart.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -22,7 +22,7 @@ class Chart:
     """
     Attributes:
         duid (str):
-        type (ChartType): * `bar` - BAR
+        type_ (ChartType): * `bar` - BAR
             * `burn-up` - BURN_UP
             * `line` - LINE
             * `number` - NUMBER
@@ -39,16 +39,16 @@ class Chart:
     """
 
     duid: str
-    type: ChartType
+    type_: ChartType
     title: str
     x: int
     y: int
     width: int
     height: int
     adtl: Union["BarChartAdtl", "BurnUpChartAdtl", "LineChartAdtl", "NumberChartAdtl", "PieChartAdtl", "TableChartAdtl"]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         from ..models.bar_chart_adtl import BarChartAdtl
         from ..models.burn_up_chart_adtl import BurnUpChartAdtl
         from ..models.line_chart_adtl import LineChartAdtl
@@ -57,7 +57,7 @@ class Chart:
 
         duid = self.duid
 
-        type = self.type.value
+        type_ = self.type_.value
 
         title = self.title
 
@@ -69,7 +69,7 @@ class Chart:
 
         height = self.height
 
-        adtl: Dict[str, Any]
+        adtl: dict[str, Any]
         if isinstance(self.adtl, BarChartAdtl):
             adtl = self.adtl.to_dict()
         elif isinstance(self.adtl, BurnUpChartAdtl):
@@ -83,12 +83,12 @@ class Chart:
         else:
             adtl = self.adtl.to_dict()
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "duid": duid,
-                "type": type,
+                "type": type_,
                 "title": title,
                 "x": x,
                 "y": y,
@@ -101,7 +101,7 @@ class Chart:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.bar_chart_adtl import BarChartAdtl
         from ..models.burn_up_chart_adtl import BurnUpChartAdtl
         from ..models.line_chart_adtl import LineChartAdtl
@@ -112,7 +112,7 @@ class Chart:
         d = src_dict.copy()
         duid = d.pop("duid")
 
-        type = ChartType(d.pop("type"))
+        type_ = ChartType(d.pop("type"))
 
         title = d.pop("title")
 
@@ -179,7 +179,7 @@ class Chart:
 
         chart = cls(
             duid=duid,
-            type=type,
+            type_=type_,
             title=title,
             x=x,
             y=y,
@@ -192,7 +192,7 @@ class Chart:
         return chart
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/chart_aggregation.py
+++ b/dart/generated/models/chart_aggregation.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class NumberChartAggregation(str, Enum):
+class ChartAggregation(str, Enum):
     AVG = "avg"
     COUNT = "count"
     SUM = "sum"

--- a/dart/generated/models/chart_type.py
+++ b/dart/generated/models/chart_type.py
@@ -3,11 +3,12 @@ from enum import Enum
 
 class ChartType(str, Enum):
     BAR = "bar"
-    BURNUP = "burnup"
+    BURN_UP = "burn-up"
     LINE = "line"
     NUMBER = "number"
     PIE = "pie"
     TABLE = "table"
+    TEXT = "text"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/dart/generated/models/comment.py
+++ b/dart/generated/models/comment.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -27,7 +27,7 @@ class Comment:
         author_duid (str):
         text (Any):
         published_at (Union[None, datetime.datetime]):
-        reactions (List['CommentReaction']):
+        reactions (list['CommentReaction']):
         is_draft (bool):
         edited (bool):
         updated_by_client_duid (Union[None, Unset, str]):
@@ -42,13 +42,13 @@ class Comment:
     author_duid: str
     text: Any
     published_at: Union[None, datetime.datetime]
-    reactions: List["CommentReaction"]
+    reactions: list["CommentReaction"]
     is_draft: bool
     edited: bool
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         created_at = self.created_at.isoformat()
@@ -87,7 +87,7 @@ class Comment:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -111,7 +111,7 @@ class Comment:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.comment_reaction import CommentReaction
 
         d = src_dict.copy()
@@ -191,7 +191,7 @@ class Comment:
         return comment
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/comment_create.py
+++ b/dart/generated/models/comment_create.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -30,9 +30,9 @@ class CommentCreate:
     root_duid: Union[None, Unset, str] = UNSET
     text: Union[Unset, Any] = UNSET
     published_at: Union[None, Unset, datetime.datetime] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         author_duid = self.author_duid
@@ -57,7 +57,7 @@ class CommentCreate:
         else:
             published_at = self.published_at
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -78,7 +78,7 @@ class CommentCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -130,7 +130,7 @@ class CommentCreate:
         return comment_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/comment_reaction.py
+++ b/dart/generated/models/comment_reaction.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -22,9 +22,9 @@ class CommentReaction:
     created_at: datetime.datetime
     author_duid: str
     emoji: str
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         created_at = self.created_at.isoformat()
@@ -33,7 +33,7 @@ class CommentReaction:
 
         emoji = self.emoji
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -47,7 +47,7 @@ class CommentReaction:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -68,7 +68,7 @@ class CommentReaction:
         return comment_reaction
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/comment_reaction_create.py
+++ b/dart/generated/models/comment_reaction_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -20,9 +20,9 @@ class CommentReactionCreate:
     author_duid: str
     comment_duid: str
     emoji: str
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         author_duid = self.author_duid
@@ -31,7 +31,7 @@ class CommentReactionCreate:
 
         emoji = self.emoji
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -45,7 +45,7 @@ class CommentReactionCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -66,7 +66,7 @@ class CommentReactionCreate:
         return comment_reaction_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/comment_reaction_update.py
+++ b/dart/generated/models/comment_reaction_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -22,9 +22,9 @@ class CommentReactionUpdate:
     author_duid: Union[Unset, str] = UNSET
     comment_duid: Union[Unset, str] = UNSET
     emoji: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         author_duid = self.author_duid
@@ -33,7 +33,7 @@ class CommentReactionUpdate:
 
         emoji = self.emoji
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -50,7 +50,7 @@ class CommentReactionUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -71,7 +71,7 @@ class CommentReactionUpdate:
         return comment_reaction_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/comment_update.py
+++ b/dart/generated/models/comment_update.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -30,9 +30,9 @@ class CommentUpdate:
     root_duid: Union[None, Unset, str] = UNSET
     text: Union[Unset, Any] = UNSET
     published_at: Union[None, Unset, datetime.datetime] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         authored_by_ai = self.authored_by_ai
@@ -57,7 +57,7 @@ class CommentUpdate:
         else:
             published_at = self.published_at
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -80,7 +80,7 @@ class CommentUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -132,7 +132,7 @@ class CommentUpdate:
         return comment_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/dartboard.py
+++ b/dart/generated/models/dartboard.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -35,14 +35,14 @@ class Dartboard:
             * `Emoji` - EMOJI
         icon_name_or_emoji (str):
         color_hex (str):
-        user_duids_to_layout_duids (List['UserDartboardLayout']):
+        user_duids_to_layout_duids (list['UserDartboardLayout']):
         index (Union[None, int]):
         started_at (Union[None, datetime.datetime]):
         finished_at (Union[None, datetime.datetime]):
         default_property_map (Any):
-        always_shown_property_duids (List[str]):
-        always_hidden_property_duids (List[str]):
-        property_order_duids (List[str]):
+        always_shown_property_duids (list[str]):
+        always_hidden_property_duids (list[str]):
+        property_order_duids (list[str]):
         property_width_map (Any):
         updated_by_client_duid (Union[None, Unset, str]):
     """
@@ -56,19 +56,19 @@ class Dartboard:
     icon_kind: IconKind
     icon_name_or_emoji: str
     color_hex: str
-    user_duids_to_layout_duids: List["UserDartboardLayout"]
+    user_duids_to_layout_duids: list["UserDartboardLayout"]
     index: Union[None, int]
     started_at: Union[None, datetime.datetime]
     finished_at: Union[None, datetime.datetime]
     default_property_map: Any
-    always_shown_property_duids: List[str]
-    always_hidden_property_duids: List[str]
-    property_order_duids: List[str]
+    always_shown_property_duids: list[str]
+    always_hidden_property_duids: list[str]
+    property_order_duids: list[str]
     property_width_map: Any
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         space_duid = self.space_duid
@@ -123,7 +123,7 @@ class Dartboard:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -153,7 +153,7 @@ class Dartboard:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.user_dartboard_layout import UserDartboardLayout
 
         d = src_dict.copy()
@@ -221,11 +221,11 @@ class Dartboard:
 
         default_property_map = d.pop("defaultPropertyMap")
 
-        always_shown_property_duids = cast(List[str], d.pop("alwaysShownPropertyDuids"))
+        always_shown_property_duids = cast(list[str], d.pop("alwaysShownPropertyDuids"))
 
-        always_hidden_property_duids = cast(List[str], d.pop("alwaysHiddenPropertyDuids"))
+        always_hidden_property_duids = cast(list[str], d.pop("alwaysHiddenPropertyDuids"))
 
-        property_order_duids = cast(List[str], d.pop("propertyOrderDuids"))
+        property_order_duids = cast(list[str], d.pop("propertyOrderDuids"))
 
         property_width_map = d.pop("propertyWidthMap")
 
@@ -264,7 +264,7 @@ class Dartboard:
         return dartboard
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/dartboard.py
+++ b/dart/generated/models/dartboard.py
@@ -39,9 +39,11 @@ class Dartboard:
         index (Union[None, int]):
         started_at (Union[None, datetime.datetime]):
         finished_at (Union[None, datetime.datetime]):
+        default_property_map (Any):
         always_shown_property_duids (List[str]):
         always_hidden_property_duids (List[str]):
         property_order_duids (List[str]):
+        property_width_map (Any):
         updated_by_client_duid (Union[None, Unset, str]):
     """
 
@@ -58,9 +60,11 @@ class Dartboard:
     index: Union[None, int]
     started_at: Union[None, datetime.datetime]
     finished_at: Union[None, datetime.datetime]
+    default_property_map: Any
     always_shown_property_duids: List[str]
     always_hidden_property_duids: List[str]
     property_order_duids: List[str]
+    property_width_map: Any
     updated_by_client_duid: Union[None, Unset, str] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -103,11 +107,15 @@ class Dartboard:
         else:
             finished_at = self.finished_at
 
+        default_property_map = self.default_property_map
+
         always_shown_property_duids = self.always_shown_property_duids
 
         always_hidden_property_duids = self.always_hidden_property_duids
 
         property_order_duids = self.property_order_duids
+
+        property_width_map = self.property_width_map
 
         updated_by_client_duid: Union[None, Unset, str]
         if isinstance(self.updated_by_client_duid, Unset):
@@ -132,9 +140,11 @@ class Dartboard:
                 "index": index,
                 "startedAt": started_at,
                 "finishedAt": finished_at,
+                "defaultPropertyMap": default_property_map,
                 "alwaysShownPropertyDuids": always_shown_property_duids,
                 "alwaysHiddenPropertyDuids": always_hidden_property_duids,
                 "propertyOrderDuids": property_order_duids,
+                "propertyWidthMap": property_width_map,
             }
         )
         if updated_by_client_duid is not UNSET:
@@ -209,11 +219,15 @@ class Dartboard:
 
         finished_at = _parse_finished_at(d.pop("finishedAt"))
 
+        default_property_map = d.pop("defaultPropertyMap")
+
         always_shown_property_duids = cast(List[str], d.pop("alwaysShownPropertyDuids"))
 
         always_hidden_property_duids = cast(List[str], d.pop("alwaysHiddenPropertyDuids"))
 
         property_order_duids = cast(List[str], d.pop("propertyOrderDuids"))
+
+        property_width_map = d.pop("propertyWidthMap")
 
         def _parse_updated_by_client_duid(data: object) -> Union[None, Unset, str]:
             if data is None:
@@ -238,9 +252,11 @@ class Dartboard:
             index=index,
             started_at=started_at,
             finished_at=finished_at,
+            default_property_map=default_property_map,
             always_shown_property_duids=always_shown_property_duids,
             always_hidden_property_duids=always_hidden_property_duids,
             property_order_duids=property_order_duids,
+            property_width_map=property_width_map,
             updated_by_client_duid=updated_by_client_duid,
         )
 

--- a/dart/generated/models/dartboard_create.py
+++ b/dart/generated/models/dartboard_create.py
@@ -34,9 +34,11 @@ class DartboardCreate:
         index (Union[None, Unset, int]):
         started_at (Union[None, Unset, datetime.datetime]):
         finished_at (Union[None, Unset, datetime.datetime]):
+        default_property_map (Union[Unset, Any]):
         always_shown_property_duids (Union[Unset, List[str]]):
         always_hidden_property_duids (Union[Unset, List[str]]):
         property_order_duids (Union[Unset, List[str]]):
+        property_width_map (Union[Unset, Any]):
     """
 
     duid: str
@@ -51,9 +53,11 @@ class DartboardCreate:
     index: Union[None, Unset, int] = UNSET
     started_at: Union[None, Unset, datetime.datetime] = UNSET
     finished_at: Union[None, Unset, datetime.datetime] = UNSET
+    default_property_map: Union[Unset, Any] = UNSET
     always_shown_property_duids: Union[Unset, List[str]] = UNSET
     always_hidden_property_duids: Union[Unset, List[str]] = UNSET
     property_order_duids: Union[Unset, List[str]] = UNSET
+    property_width_map: Union[Unset, Any] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -101,6 +105,8 @@ class DartboardCreate:
         else:
             finished_at = self.finished_at
 
+        default_property_map = self.default_property_map
+
         always_shown_property_duids: Union[Unset, List[str]] = UNSET
         if not isinstance(self.always_shown_property_duids, Unset):
             always_shown_property_duids = self.always_shown_property_duids
@@ -112,6 +118,8 @@ class DartboardCreate:
         property_order_duids: Union[Unset, List[str]] = UNSET
         if not isinstance(self.property_order_duids, Unset):
             property_order_duids = self.property_order_duids
+
+        property_width_map = self.property_width_map
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -140,12 +148,16 @@ class DartboardCreate:
             field_dict["startedAt"] = started_at
         if finished_at is not UNSET:
             field_dict["finishedAt"] = finished_at
+        if default_property_map is not UNSET:
+            field_dict["defaultPropertyMap"] = default_property_map
         if always_shown_property_duids is not UNSET:
             field_dict["alwaysShownPropertyDuids"] = always_shown_property_duids
         if always_hidden_property_duids is not UNSET:
             field_dict["alwaysHiddenPropertyDuids"] = always_hidden_property_duids
         if property_order_duids is not UNSET:
             field_dict["propertyOrderDuids"] = property_order_duids
+        if property_width_map is not UNSET:
+            field_dict["propertyWidthMap"] = property_width_map
 
         return field_dict
 
@@ -223,11 +235,15 @@ class DartboardCreate:
 
         finished_at = _parse_finished_at(d.pop("finishedAt", UNSET))
 
+        default_property_map = d.pop("defaultPropertyMap", UNSET)
+
         always_shown_property_duids = cast(List[str], d.pop("alwaysShownPropertyDuids", UNSET))
 
         always_hidden_property_duids = cast(List[str], d.pop("alwaysHiddenPropertyDuids", UNSET))
 
         property_order_duids = cast(List[str], d.pop("propertyOrderDuids", UNSET))
+
+        property_width_map = d.pop("propertyWidthMap", UNSET)
 
         dartboard_create = cls(
             duid=duid,
@@ -242,9 +258,11 @@ class DartboardCreate:
             index=index,
             started_at=started_at,
             finished_at=finished_at,
+            default_property_map=default_property_map,
             always_shown_property_duids=always_shown_property_duids,
             always_hidden_property_duids=always_hidden_property_duids,
             property_order_duids=property_order_duids,
+            property_width_map=property_width_map,
         )
 
         dartboard_create.additional_properties = d

--- a/dart/generated/models/dartboard_create.py
+++ b/dart/generated/models/dartboard_create.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -35,9 +35,9 @@ class DartboardCreate:
         started_at (Union[None, Unset, datetime.datetime]):
         finished_at (Union[None, Unset, datetime.datetime]):
         default_property_map (Union[Unset, Any]):
-        always_shown_property_duids (Union[Unset, List[str]]):
-        always_hidden_property_duids (Union[Unset, List[str]]):
-        property_order_duids (Union[Unset, List[str]]):
+        always_shown_property_duids (Union[Unset, list[str]]):
+        always_hidden_property_duids (Union[Unset, list[str]]):
+        property_order_duids (Union[Unset, list[str]]):
         property_width_map (Union[Unset, Any]):
     """
 
@@ -54,13 +54,13 @@ class DartboardCreate:
     started_at: Union[None, Unset, datetime.datetime] = UNSET
     finished_at: Union[None, Unset, datetime.datetime] = UNSET
     default_property_map: Union[Unset, Any] = UNSET
-    always_shown_property_duids: Union[Unset, List[str]] = UNSET
-    always_hidden_property_duids: Union[Unset, List[str]] = UNSET
-    property_order_duids: Union[Unset, List[str]] = UNSET
+    always_shown_property_duids: Union[Unset, list[str]] = UNSET
+    always_hidden_property_duids: Union[Unset, list[str]] = UNSET
+    property_order_duids: Union[Unset, list[str]] = UNSET
     property_width_map: Union[Unset, Any] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         space_duid = self.space_duid
@@ -107,21 +107,21 @@ class DartboardCreate:
 
         default_property_map = self.default_property_map
 
-        always_shown_property_duids: Union[Unset, List[str]] = UNSET
+        always_shown_property_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.always_shown_property_duids, Unset):
             always_shown_property_duids = self.always_shown_property_duids
 
-        always_hidden_property_duids: Union[Unset, List[str]] = UNSET
+        always_hidden_property_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.always_hidden_property_duids, Unset):
             always_hidden_property_duids = self.always_hidden_property_duids
 
-        property_order_duids: Union[Unset, List[str]] = UNSET
+        property_order_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.property_order_duids, Unset):
             property_order_duids = self.property_order_duids
 
         property_width_map = self.property_width_map
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -162,7 +162,7 @@ class DartboardCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -237,11 +237,11 @@ class DartboardCreate:
 
         default_property_map = d.pop("defaultPropertyMap", UNSET)
 
-        always_shown_property_duids = cast(List[str], d.pop("alwaysShownPropertyDuids", UNSET))
+        always_shown_property_duids = cast(list[str], d.pop("alwaysShownPropertyDuids", UNSET))
 
-        always_hidden_property_duids = cast(List[str], d.pop("alwaysHiddenPropertyDuids", UNSET))
+        always_hidden_property_duids = cast(list[str], d.pop("alwaysHiddenPropertyDuids", UNSET))
 
-        property_order_duids = cast(List[str], d.pop("propertyOrderDuids", UNSET))
+        property_order_duids = cast(list[str], d.pop("propertyOrderDuids", UNSET))
 
         property_width_map = d.pop("propertyWidthMap", UNSET)
 
@@ -269,7 +269,7 @@ class DartboardCreate:
         return dartboard_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/dartboard_update.py
+++ b/dart/generated/models/dartboard_update.py
@@ -34,9 +34,11 @@ class DartboardUpdate:
         index (Union[None, Unset, int]):
         started_at (Union[None, Unset, datetime.datetime]):
         finished_at (Union[None, Unset, datetime.datetime]):
+        default_property_map (Union[Unset, Any]):
         always_shown_property_duids (Union[Unset, List[str]]):
         always_hidden_property_duids (Union[Unset, List[str]]):
         property_order_duids (Union[Unset, List[str]]):
+        property_width_map (Union[Unset, Any]):
     """
 
     duid: str
@@ -51,9 +53,11 @@ class DartboardUpdate:
     index: Union[None, Unset, int] = UNSET
     started_at: Union[None, Unset, datetime.datetime] = UNSET
     finished_at: Union[None, Unset, datetime.datetime] = UNSET
+    default_property_map: Union[Unset, Any] = UNSET
     always_shown_property_duids: Union[Unset, List[str]] = UNSET
     always_hidden_property_duids: Union[Unset, List[str]] = UNSET
     property_order_duids: Union[Unset, List[str]] = UNSET
+    property_width_map: Union[Unset, Any] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -101,6 +105,8 @@ class DartboardUpdate:
         else:
             finished_at = self.finished_at
 
+        default_property_map = self.default_property_map
+
         always_shown_property_duids: Union[Unset, List[str]] = UNSET
         if not isinstance(self.always_shown_property_duids, Unset):
             always_shown_property_duids = self.always_shown_property_duids
@@ -112,6 +118,8 @@ class DartboardUpdate:
         property_order_duids: Union[Unset, List[str]] = UNSET
         if not isinstance(self.property_order_duids, Unset):
             property_order_duids = self.property_order_duids
+
+        property_width_map = self.property_width_map
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -142,12 +150,16 @@ class DartboardUpdate:
             field_dict["startedAt"] = started_at
         if finished_at is not UNSET:
             field_dict["finishedAt"] = finished_at
+        if default_property_map is not UNSET:
+            field_dict["defaultPropertyMap"] = default_property_map
         if always_shown_property_duids is not UNSET:
             field_dict["alwaysShownPropertyDuids"] = always_shown_property_duids
         if always_hidden_property_duids is not UNSET:
             field_dict["alwaysHiddenPropertyDuids"] = always_hidden_property_duids
         if property_order_duids is not UNSET:
             field_dict["propertyOrderDuids"] = property_order_duids
+        if property_width_map is not UNSET:
+            field_dict["propertyWidthMap"] = property_width_map
 
         return field_dict
 
@@ -225,11 +237,15 @@ class DartboardUpdate:
 
         finished_at = _parse_finished_at(d.pop("finishedAt", UNSET))
 
+        default_property_map = d.pop("defaultPropertyMap", UNSET)
+
         always_shown_property_duids = cast(List[str], d.pop("alwaysShownPropertyDuids", UNSET))
 
         always_hidden_property_duids = cast(List[str], d.pop("alwaysHiddenPropertyDuids", UNSET))
 
         property_order_duids = cast(List[str], d.pop("propertyOrderDuids", UNSET))
+
+        property_width_map = d.pop("propertyWidthMap", UNSET)
 
         dartboard_update = cls(
             duid=duid,
@@ -244,9 +260,11 @@ class DartboardUpdate:
             index=index,
             started_at=started_at,
             finished_at=finished_at,
+            default_property_map=default_property_map,
             always_shown_property_duids=always_shown_property_duids,
             always_hidden_property_duids=always_hidden_property_duids,
             property_order_duids=property_order_duids,
+            property_width_map=property_width_map,
         )
 
         dartboard_update.additional_properties = d

--- a/dart/generated/models/dartboard_update.py
+++ b/dart/generated/models/dartboard_update.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -35,9 +35,9 @@ class DartboardUpdate:
         started_at (Union[None, Unset, datetime.datetime]):
         finished_at (Union[None, Unset, datetime.datetime]):
         default_property_map (Union[Unset, Any]):
-        always_shown_property_duids (Union[Unset, List[str]]):
-        always_hidden_property_duids (Union[Unset, List[str]]):
-        property_order_duids (Union[Unset, List[str]]):
+        always_shown_property_duids (Union[Unset, list[str]]):
+        always_hidden_property_duids (Union[Unset, list[str]]):
+        property_order_duids (Union[Unset, list[str]]):
         property_width_map (Union[Unset, Any]):
     """
 
@@ -54,13 +54,13 @@ class DartboardUpdate:
     started_at: Union[None, Unset, datetime.datetime] = UNSET
     finished_at: Union[None, Unset, datetime.datetime] = UNSET
     default_property_map: Union[Unset, Any] = UNSET
-    always_shown_property_duids: Union[Unset, List[str]] = UNSET
-    always_hidden_property_duids: Union[Unset, List[str]] = UNSET
-    property_order_duids: Union[Unset, List[str]] = UNSET
+    always_shown_property_duids: Union[Unset, list[str]] = UNSET
+    always_hidden_property_duids: Union[Unset, list[str]] = UNSET
+    property_order_duids: Union[Unset, list[str]] = UNSET
     property_width_map: Union[Unset, Any] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         space_duid = self.space_duid
@@ -107,21 +107,21 @@ class DartboardUpdate:
 
         default_property_map = self.default_property_map
 
-        always_shown_property_duids: Union[Unset, List[str]] = UNSET
+        always_shown_property_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.always_shown_property_duids, Unset):
             always_shown_property_duids = self.always_shown_property_duids
 
-        always_hidden_property_duids: Union[Unset, List[str]] = UNSET
+        always_hidden_property_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.always_hidden_property_duids, Unset):
             always_hidden_property_duids = self.always_hidden_property_duids
 
-        property_order_duids: Union[Unset, List[str]] = UNSET
+        property_order_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.property_order_duids, Unset):
             property_order_duids = self.property_order_duids
 
         property_width_map = self.property_width_map
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -164,7 +164,7 @@ class DartboardUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -239,11 +239,11 @@ class DartboardUpdate:
 
         default_property_map = d.pop("defaultPropertyMap", UNSET)
 
-        always_shown_property_duids = cast(List[str], d.pop("alwaysShownPropertyDuids", UNSET))
+        always_shown_property_duids = cast(list[str], d.pop("alwaysShownPropertyDuids", UNSET))
 
-        always_hidden_property_duids = cast(List[str], d.pop("alwaysHiddenPropertyDuids", UNSET))
+        always_hidden_property_duids = cast(list[str], d.pop("alwaysHiddenPropertyDuids", UNSET))
 
-        property_order_duids = cast(List[str], d.pop("propertyOrderDuids", UNSET))
+        property_order_duids = cast(list[str], d.pop("propertyOrderDuids", UNSET))
 
         property_width_map = d.pop("propertyWidthMap", UNSET)
 
@@ -271,7 +271,7 @@ class DartboardUpdate:
         return dartboard_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/dashboard.py
+++ b/dart/generated/models/dashboard.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -19,7 +19,7 @@ class Dashboard:
     Attributes:
         duid (str):
         accessible_by_team (bool):
-        accessible_by_user_duids (List[str]):
+        accessible_by_user_duids (list[str]):
         order (str):
         title (str):
         description (str):
@@ -29,14 +29,14 @@ class Dashboard:
         icon_name_or_emoji (str):
         color_hex (str):
         layout_duid (str):
-        favorited_by_user_duids (List[str]):
-        charts (List['Chart']):
+        favorited_by_user_duids (list[str]):
+        charts (list['Chart']):
         updated_by_client_duid (Union[None, Unset, str]):
     """
 
     duid: str
     accessible_by_team: bool
-    accessible_by_user_duids: List[str]
+    accessible_by_user_duids: list[str]
     order: str
     title: str
     description: str
@@ -44,12 +44,12 @@ class Dashboard:
     icon_name_or_emoji: str
     color_hex: str
     layout_duid: str
-    favorited_by_user_duids: List[str]
-    charts: List["Chart"]
+    favorited_by_user_duids: list[str]
+    charts: list["Chart"]
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         accessible_by_team = self.accessible_by_team
@@ -83,7 +83,7 @@ class Dashboard:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -107,7 +107,7 @@ class Dashboard:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.chart import Chart
 
         d = src_dict.copy()
@@ -115,7 +115,7 @@ class Dashboard:
 
         accessible_by_team = d.pop("accessibleByTeam")
 
-        accessible_by_user_duids = cast(List[str], d.pop("accessibleByUserDuids"))
+        accessible_by_user_duids = cast(list[str], d.pop("accessibleByUserDuids"))
 
         order = d.pop("order")
 
@@ -131,7 +131,7 @@ class Dashboard:
 
         layout_duid = d.pop("layoutDuid")
 
-        favorited_by_user_duids = cast(List[str], d.pop("favoritedByUserDuids"))
+        favorited_by_user_duids = cast(list[str], d.pop("favoritedByUserDuids"))
 
         charts = []
         _charts = d.pop("charts")
@@ -169,7 +169,7 @@ class Dashboard:
         return dashboard
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/dashboard_create.py
+++ b/dart/generated/models/dashboard_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,7 +17,7 @@ class DashboardCreate:
         order (str):
         layout_duid (str):
         accessible_by_team (Union[Unset, bool]):
-        accessible_by_user_duids (Union[Unset, List[str]]):
+        accessible_by_user_duids (Union[Unset, list[str]]):
         title (Union[Unset, str]):
         description (Union[Unset, str]):
         icon_kind (Union[Unset, IconKind]): * `None` - NONE
@@ -25,7 +25,7 @@ class DashboardCreate:
             * `Emoji` - EMOJI
         icon_name_or_emoji (Union[Unset, str]):
         color_hex (Union[Unset, str]):
-        favorited_by_user_duids (Union[Unset, List[str]]):
+        favorited_by_user_duids (Union[Unset, list[str]]):
         charts (Union[Unset, Any]):
     """
 
@@ -33,17 +33,17 @@ class DashboardCreate:
     order: str
     layout_duid: str
     accessible_by_team: Union[Unset, bool] = UNSET
-    accessible_by_user_duids: Union[Unset, List[str]] = UNSET
+    accessible_by_user_duids: Union[Unset, list[str]] = UNSET
     title: Union[Unset, str] = UNSET
     description: Union[Unset, str] = UNSET
     icon_kind: Union[Unset, IconKind] = UNSET
     icon_name_or_emoji: Union[Unset, str] = UNSET
     color_hex: Union[Unset, str] = UNSET
-    favorited_by_user_duids: Union[Unset, List[str]] = UNSET
+    favorited_by_user_duids: Union[Unset, list[str]] = UNSET
     charts: Union[Unset, Any] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         order = self.order
@@ -52,7 +52,7 @@ class DashboardCreate:
 
         accessible_by_team = self.accessible_by_team
 
-        accessible_by_user_duids: Union[Unset, List[str]] = UNSET
+        accessible_by_user_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.accessible_by_user_duids, Unset):
             accessible_by_user_duids = self.accessible_by_user_duids
 
@@ -68,13 +68,13 @@ class DashboardCreate:
 
         color_hex = self.color_hex
 
-        favorited_by_user_duids: Union[Unset, List[str]] = UNSET
+        favorited_by_user_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.favorited_by_user_duids, Unset):
             favorited_by_user_duids = self.favorited_by_user_duids
 
         charts = self.charts
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -105,7 +105,7 @@ class DashboardCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -115,7 +115,7 @@ class DashboardCreate:
 
         accessible_by_team = d.pop("accessibleByTeam", UNSET)
 
-        accessible_by_user_duids = cast(List[str], d.pop("accessibleByUserDuids", UNSET))
+        accessible_by_user_duids = cast(list[str], d.pop("accessibleByUserDuids", UNSET))
 
         title = d.pop("title", UNSET)
 
@@ -132,7 +132,7 @@ class DashboardCreate:
 
         color_hex = d.pop("colorHex", UNSET)
 
-        favorited_by_user_duids = cast(List[str], d.pop("favoritedByUserDuids", UNSET))
+        favorited_by_user_duids = cast(list[str], d.pop("favoritedByUserDuids", UNSET))
 
         charts = d.pop("charts", UNSET)
 
@@ -155,7 +155,7 @@ class DashboardCreate:
         return dashboard_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/dashboard_update.py
+++ b/dart/generated/models/dashboard_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -15,7 +15,7 @@ class DashboardUpdate:
     Attributes:
         duid (str):
         accessible_by_team (Union[Unset, bool]):
-        accessible_by_user_duids (Union[Unset, List[str]]):
+        accessible_by_user_duids (Union[Unset, list[str]]):
         order (Union[Unset, str]):
         title (Union[Unset, str]):
         description (Union[Unset, str]):
@@ -25,13 +25,13 @@ class DashboardUpdate:
         icon_name_or_emoji (Union[Unset, str]):
         color_hex (Union[Unset, str]):
         layout_duid (Union[Unset, str]):
-        favorited_by_user_duids (Union[Unset, List[str]]):
+        favorited_by_user_duids (Union[Unset, list[str]]):
         charts (Union[Unset, Any]):
     """
 
     duid: str
     accessible_by_team: Union[Unset, bool] = UNSET
-    accessible_by_user_duids: Union[Unset, List[str]] = UNSET
+    accessible_by_user_duids: Union[Unset, list[str]] = UNSET
     order: Union[Unset, str] = UNSET
     title: Union[Unset, str] = UNSET
     description: Union[Unset, str] = UNSET
@@ -39,16 +39,16 @@ class DashboardUpdate:
     icon_name_or_emoji: Union[Unset, str] = UNSET
     color_hex: Union[Unset, str] = UNSET
     layout_duid: Union[Unset, str] = UNSET
-    favorited_by_user_duids: Union[Unset, List[str]] = UNSET
+    favorited_by_user_duids: Union[Unset, list[str]] = UNSET
     charts: Union[Unset, Any] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         accessible_by_team = self.accessible_by_team
 
-        accessible_by_user_duids: Union[Unset, List[str]] = UNSET
+        accessible_by_user_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.accessible_by_user_duids, Unset):
             accessible_by_user_duids = self.accessible_by_user_duids
 
@@ -68,13 +68,13 @@ class DashboardUpdate:
 
         layout_duid = self.layout_duid
 
-        favorited_by_user_duids: Union[Unset, List[str]] = UNSET
+        favorited_by_user_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.favorited_by_user_duids, Unset):
             favorited_by_user_duids = self.favorited_by_user_duids
 
         charts = self.charts
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -107,13 +107,13 @@ class DashboardUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
         accessible_by_team = d.pop("accessibleByTeam", UNSET)
 
-        accessible_by_user_duids = cast(List[str], d.pop("accessibleByUserDuids", UNSET))
+        accessible_by_user_duids = cast(list[str], d.pop("accessibleByUserDuids", UNSET))
 
         order = d.pop("order", UNSET)
 
@@ -134,7 +134,7 @@ class DashboardUpdate:
 
         layout_duid = d.pop("layoutDuid", UNSET)
 
-        favorited_by_user_duids = cast(List[str], d.pop("favoritedByUserDuids", UNSET))
+        favorited_by_user_duids = cast(list[str], d.pop("favoritedByUserDuids", UNSET))
 
         charts = d.pop("charts", UNSET)
 
@@ -157,7 +157,7 @@ class DashboardUpdate:
         return dashboard_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/discord_integration.py
+++ b/dart/generated/models/discord_integration.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -16,15 +16,15 @@ class DiscordIntegration:
 
     enabled: bool
     webhook_url: Union[None, str]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         enabled = self.enabled
 
         webhook_url: Union[None, str]
         webhook_url = self.webhook_url
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -36,7 +36,7 @@ class DiscordIntegration:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         enabled = d.pop("enabled")
 
@@ -56,7 +56,7 @@ class DiscordIntegration:
         return discord_integration
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/doc.py
+++ b/dart/generated/models/doc.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -28,8 +28,8 @@ class Doc:
         text (Any):
         edited_by_ai (bool):
         recommendation_duid (Union[None, str]):
-        editor_duids (List[str]):
-        subscriber_duids (List[str]):
+        editor_duids (list[str]):
+        subscriber_duids (list[str]):
         icon_kind (IconKind): * `None` - NONE
             * `Icon` - ICON
             * `Emoji` - EMOJI
@@ -50,15 +50,15 @@ class Doc:
     text: Any
     edited_by_ai: bool
     recommendation_duid: Union[None, str]
-    editor_duids: List[str]
-    subscriber_duids: List[str]
+    editor_duids: list[str]
+    subscriber_duids: list[str]
     icon_kind: IconKind
     icon_name_or_emoji: str
     color_hex: str
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         created_at = self.created_at.isoformat()
@@ -105,7 +105,7 @@ class Doc:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -134,7 +134,7 @@ class Doc:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -183,9 +183,9 @@ class Doc:
 
         recommendation_duid = _parse_recommendation_duid(d.pop("recommendationDuid"))
 
-        editor_duids = cast(List[str], d.pop("editorDuids"))
+        editor_duids = cast(list[str], d.pop("editorDuids"))
 
-        subscriber_duids = cast(List[str], d.pop("subscriberDuids"))
+        subscriber_duids = cast(list[str], d.pop("subscriberDuids"))
 
         icon_kind = IconKind(d.pop("iconKind"))
 
@@ -227,7 +227,7 @@ class Doc:
         return doc
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/doc_create.py
+++ b/dart/generated/models/doc_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -33,8 +33,8 @@ class DocCreate:
         text_markdown (Union[Unset, str]):
         edited_by_ai (Union[Unset, bool]):
         recommendation_duid (Union[None, Unset, str]):
-        editor_duids (Union[Unset, List[str]]):
-        subscriber_duids (Union[Unset, List[str]]):
+        editor_duids (Union[Unset, list[str]]):
+        subscriber_duids (Union[Unset, list[str]]):
         icon_kind (Union[Unset, IconKind]): * `None` - NONE
             * `Icon` - ICON
             * `Emoji` - EMOJI
@@ -55,14 +55,14 @@ class DocCreate:
     text_markdown: Union[Unset, str] = UNSET
     edited_by_ai: Union[Unset, bool] = UNSET
     recommendation_duid: Union[None, Unset, str] = UNSET
-    editor_duids: Union[Unset, List[str]] = UNSET
-    subscriber_duids: Union[Unset, List[str]] = UNSET
+    editor_duids: Union[Unset, list[str]] = UNSET
+    subscriber_duids: Union[Unset, list[str]] = UNSET
     icon_kind: Union[Unset, IconKind] = UNSET
     icon_name_or_emoji: Union[Unset, str] = UNSET
     color_hex: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         source_user: Union[None, Unset, str]
@@ -109,11 +109,11 @@ class DocCreate:
         else:
             recommendation_duid = self.recommendation_duid
 
-        editor_duids: Union[Unset, List[str]] = UNSET
+        editor_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.editor_duids, Unset):
             editor_duids = self.editor_duids
 
-        subscriber_duids: Union[Unset, List[str]] = UNSET
+        subscriber_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.subscriber_duids, Unset):
             subscriber_duids = self.subscriber_duids
 
@@ -125,7 +125,7 @@ class DocCreate:
 
         color_hex = self.color_hex
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -170,7 +170,7 @@ class DocCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -239,9 +239,9 @@ class DocCreate:
 
         recommendation_duid = _parse_recommendation_duid(d.pop("recommendationDuid", UNSET))
 
-        editor_duids = cast(List[str], d.pop("editorDuids", UNSET))
+        editor_duids = cast(list[str], d.pop("editorDuids", UNSET))
 
-        subscriber_duids = cast(List[str], d.pop("subscriberDuids", UNSET))
+        subscriber_duids = cast(list[str], d.pop("subscriberDuids", UNSET))
 
         _icon_kind = d.pop("iconKind", UNSET)
         icon_kind: Union[Unset, IconKind]
@@ -279,7 +279,7 @@ class DocCreate:
         return doc_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/doc_update.py
+++ b/dart/generated/models/doc_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -33,8 +33,8 @@ class DocUpdate:
         text_markdown (Union[Unset, str]):
         edited_by_ai (Union[Unset, bool]):
         recommendation_duid (Union[None, Unset, str]):
-        editor_duids (Union[Unset, List[str]]):
-        subscriber_duids (Union[Unset, List[str]]):
+        editor_duids (Union[Unset, list[str]]):
+        subscriber_duids (Union[Unset, list[str]]):
         icon_kind (Union[Unset, IconKind]): * `None` - NONE
             * `Icon` - ICON
             * `Emoji` - EMOJI
@@ -55,14 +55,14 @@ class DocUpdate:
     text_markdown: Union[Unset, str] = UNSET
     edited_by_ai: Union[Unset, bool] = UNSET
     recommendation_duid: Union[None, Unset, str] = UNSET
-    editor_duids: Union[Unset, List[str]] = UNSET
-    subscriber_duids: Union[Unset, List[str]] = UNSET
+    editor_duids: Union[Unset, list[str]] = UNSET
+    subscriber_duids: Union[Unset, list[str]] = UNSET
     icon_kind: Union[Unset, IconKind] = UNSET
     icon_name_or_emoji: Union[Unset, str] = UNSET
     color_hex: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         source_user: Union[None, Unset, str]
@@ -109,11 +109,11 @@ class DocUpdate:
         else:
             recommendation_duid = self.recommendation_duid
 
-        editor_duids: Union[Unset, List[str]] = UNSET
+        editor_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.editor_duids, Unset):
             editor_duids = self.editor_duids
 
-        subscriber_duids: Union[Unset, List[str]] = UNSET
+        subscriber_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.subscriber_duids, Unset):
             subscriber_duids = self.subscriber_duids
 
@@ -125,7 +125,7 @@ class DocUpdate:
 
         color_hex = self.color_hex
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -170,7 +170,7 @@ class DocUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -239,9 +239,9 @@ class DocUpdate:
 
         recommendation_duid = _parse_recommendation_duid(d.pop("recommendationDuid", UNSET))
 
-        editor_duids = cast(List[str], d.pop("editorDuids", UNSET))
+        editor_duids = cast(list[str], d.pop("editorDuids", UNSET))
 
-        subscriber_duids = cast(List[str], d.pop("subscriberDuids", UNSET))
+        subscriber_duids = cast(list[str], d.pop("subscriberDuids", UNSET))
 
         _icon_kind = d.pop("iconKind", UNSET)
         icon_kind: Union[Unset, IconKind]
@@ -279,7 +279,7 @@ class DocUpdate:
         return doc_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/event.py
+++ b/dart/generated/models/event.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -14,7 +14,7 @@ T = TypeVar("T", bound="Event")
 class Event:
     """
     Attributes:
-        message_frags (Union[List[Any], None]):
+        message_frags (Union[None, list[Any]]):
         kind (EventKind): * `tasks/create` - TASK_CREATE
             * `tasks/update_assignees` - TASK_UPDATE_ASSIGNEES
             * `tasks/update_status` - TASK_UPDATE_STATUS
@@ -129,7 +129,7 @@ class Event:
         adtl (Any):
     """
 
-    message_frags: Union[List[Any], None]
+    message_frags: Union[None, list[Any]]
     kind: EventKind
     actor_duid: Union[None, str]
     actor_str: Union[EventActor, None]
@@ -148,10 +148,10 @@ class Event:
     status_duid: Union[None, str]
     user_duid: Union[None, str]
     adtl: Any
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
-        message_frags: Union[List[Any], None]
+    def to_dict(self) -> dict[str, Any]:
+        message_frags: Union[None, list[Any]]
         if isinstance(self.message_frags, list):
             message_frags = self.message_frags
 
@@ -212,7 +212,7 @@ class Event:
 
         adtl = self.adtl
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -241,21 +241,21 @@ class Event:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
 
-        def _parse_message_frags(data: object) -> Union[List[Any], None]:
+        def _parse_message_frags(data: object) -> Union[None, list[Any]]:
             if data is None:
                 return data
             try:
                 if not isinstance(data, list):
                     raise TypeError()
-                message_frags_type_0 = cast(List[Any], data)
+                message_frags_type_0 = cast(list[Any], data)
 
                 return message_frags_type_0
             except:  # noqa: E722
                 pass
-            return cast(Union[List[Any], None], data)
+            return cast(Union[None, list[Any]], data)
 
         message_frags = _parse_message_frags(d.pop("messageFrags"))
 
@@ -404,7 +404,7 @@ class Event:
         return event
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/event_actor.py
+++ b/dart/generated/models/event_actor.py
@@ -12,6 +12,7 @@ class EventActor(str, Enum):
     DART_REMINDER_BOT = "Dart Reminder Bot"
     DART_REPORT_BOT = "Dart Report Bot"
     DART_SLACK_BOT = "Dart Slack Bot"
+    DART_SPRINT_BOT = "Dart Sprint Bot"
     STRIPE_WEBHOOK = "Stripe webhook"
 
     def __str__(self) -> str:

--- a/dart/generated/models/event_create.py
+++ b/dart/generated/models/event_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -101,16 +101,16 @@ class EventCreate:
     kind: EventKind
     actor_duid: str
     adtl: Union[Unset, Any] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         kind = self.kind.value
 
         actor_duid = self.actor_duid
 
         adtl = self.adtl
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -124,7 +124,7 @@ class EventCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         kind = EventKind(d.pop("kind"))
 
@@ -142,7 +142,7 @@ class EventCreate:
         return event_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/event_subscription.py
+++ b/dart/generated/models/event_subscription.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -18,16 +18,16 @@ class EventSubscription:
     in_app: bool
     email: bool
     slack: bool
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         in_app = self.in_app
 
         email = self.email
 
         slack = self.slack
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -40,7 +40,7 @@ class EventSubscription:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         in_app = d.pop("inApp")
 
@@ -58,7 +58,7 @@ class EventSubscription:
         return event_subscription
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/event_subscription_update.py
+++ b/dart/generated/models/event_subscription_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -103,9 +103,9 @@ class EventSubscriptionUpdate:
     in_app: Union[Unset, bool] = UNSET
     email: Union[Unset, bool] = UNSET
     slack: Union[Unset, bool] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         kind: Union[Unset, str] = UNSET
         if not isinstance(self.kind, Unset):
             kind = self.kind.value
@@ -116,7 +116,7 @@ class EventSubscriptionUpdate:
 
         slack = self.slack
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if kind is not UNSET:
@@ -131,7 +131,7 @@ class EventSubscriptionUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         _kind = d.pop("kind", UNSET)
         kind: Union[Unset, EventKind]
@@ -157,7 +157,7 @@ class EventSubscriptionUpdate:
         return event_subscription_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/filter_assignee.py
+++ b/dart/generated/models/filter_assignee.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -33,7 +33,7 @@ class FilterAssignee:
             * `is unchecked` - IS_UNCHECKED
         connector (FilterConnector): * `or` - OR
             * `and` - AND
-        values (List[Any]):
+        values (list[Any]):
     """
 
     id: str
@@ -41,10 +41,10 @@ class FilterAssignee:
     locked: bool
     applicability: FilterApplicability
     connector: FilterConnector
-    values: List[Any]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    values: list[Any]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         id = self.id
 
         field = self.field
@@ -57,7 +57,7 @@ class FilterAssignee:
 
         values = self.values
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -73,7 +73,7 @@ class FilterAssignee:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         id = d.pop("id")
 
@@ -85,7 +85,7 @@ class FilterAssignee:
 
         connector = FilterConnector(d.pop("connector"))
 
-        values = cast(List[Any], d.pop("values"))
+        values = cast(list[Any], d.pop("values"))
 
         filter_assignee = cls(
             id=id,
@@ -100,7 +100,7 @@ class FilterAssignee:
         return filter_assignee
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/filter_group.py
+++ b/dart/generated/models/filter_group.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -25,13 +25,13 @@ class FilterGroup:
 
     filters: Union["FilterAssignee", "FilterSearch", "FilterSet"]
     connector: FilterConnector
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         from ..models.filter_assignee import FilterAssignee
         from ..models.filter_set import FilterSet
 
-        filters: Dict[str, Any]
+        filters: dict[str, Any]
         if isinstance(self.filters, FilterAssignee):
             filters = self.filters.to_dict()
         elif isinstance(self.filters, FilterSet):
@@ -41,7 +41,7 @@ class FilterGroup:
 
         connector = self.connector.value
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -53,7 +53,7 @@ class FilterGroup:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.filter_assignee import FilterAssignee
         from ..models.filter_search import FilterSearch
         from ..models.filter_set import FilterSet
@@ -96,7 +96,7 @@ class FilterGroup:
         return filter_group
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/filter_search.py
+++ b/dart/generated/models/filter_search.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -13,16 +13,16 @@ class FilterSearch:
         id (str):
         field (str):
         locked (bool):
-        values (List[Any]):
+        values (list[Any]):
     """
 
     id: str
     field: str
     locked: bool
-    values: List[Any]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    values: list[Any]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         id = self.id
 
         field = self.field
@@ -31,7 +31,7 @@ class FilterSearch:
 
         values = self.values
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -45,7 +45,7 @@ class FilterSearch:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         id = d.pop("id")
 
@@ -53,7 +53,7 @@ class FilterSearch:
 
         locked = d.pop("locked")
 
-        values = cast(List[Any], d.pop("values"))
+        values = cast(list[Any], d.pop("values"))
 
         filter_search = cls(
             id=id,
@@ -66,7 +66,7 @@ class FilterSearch:
         return filter_search
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/filter_set.py
+++ b/dart/generated/models/filter_set.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -33,7 +33,7 @@ class FilterSet:
             * `is unchecked` - IS_UNCHECKED
         connector (FilterConnector): * `or` - OR
             * `and` - AND
-        values (List[Any]):
+        values (list[Any]):
     """
 
     id: str
@@ -41,10 +41,10 @@ class FilterSet:
     locked: bool
     applicability: FilterApplicability
     connector: FilterConnector
-    values: List[Any]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    values: list[Any]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         id = self.id
 
         field = self.field
@@ -57,7 +57,7 @@ class FilterSet:
 
         values = self.values
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -73,7 +73,7 @@ class FilterSet:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         id = d.pop("id")
 
@@ -85,7 +85,7 @@ class FilterSet:
 
         connector = FilterConnector(d.pop("connector"))
 
-        values = cast(List[Any], d.pop("values"))
+        values = cast(list[Any], d.pop("values"))
 
         filter_set = cls(
             id=id,
@@ -100,7 +100,7 @@ class FilterSet:
         return filter_set
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/folder.py
+++ b/dart/generated/models/folder.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -40,9 +40,9 @@ class Folder:
     icon_name_or_emoji: str
     color_hex: str
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         space_duid = self.space_duid
@@ -67,7 +67,7 @@ class Folder:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -88,7 +88,7 @@ class Folder:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -134,7 +134,7 @@ class Folder:
         return folder
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/folder_create.py
+++ b/dart/generated/models/folder_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -38,9 +38,9 @@ class FolderCreate:
     icon_kind: Union[Unset, IconKind] = UNSET
     icon_name_or_emoji: Union[Unset, str] = UNSET
     color_hex: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         space_duid = self.space_duid
@@ -63,7 +63,7 @@ class FolderCreate:
 
         color_hex = self.color_hex
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -88,7 +88,7 @@ class FolderCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -134,7 +134,7 @@ class FolderCreate:
         return folder_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/folder_update.py
+++ b/dart/generated/models/folder_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -38,9 +38,9 @@ class FolderUpdate:
     icon_kind: Union[Unset, IconKind] = UNSET
     icon_name_or_emoji: Union[Unset, str] = UNSET
     color_hex: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         space_duid = self.space_duid
@@ -63,7 +63,7 @@ class FolderUpdate:
 
         color_hex = self.color_hex
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -90,7 +90,7 @@ class FolderUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -136,7 +136,7 @@ class FolderUpdate:
         return folder_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/form.py
+++ b/dart/generated/models/form.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -37,9 +37,9 @@ class Form:
     icon_name_or_emoji: str
     color_hex: str
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         hidden = self.hidden
@@ -64,7 +64,7 @@ class Form:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -85,7 +85,7 @@ class Form:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -131,7 +131,7 @@ class Form:
         return form
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/form_create.py
+++ b/dart/generated/models/form_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -35,9 +35,9 @@ class FormCreate:
     icon_kind: Union[Unset, IconKind] = UNSET
     icon_name_or_emoji: Union[Unset, str] = UNSET
     color_hex: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         order = self.order
@@ -58,7 +58,7 @@ class FormCreate:
 
         color_hex = self.color_hex
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -84,7 +84,7 @@ class FormCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -125,7 +125,7 @@ class FormCreate:
         return form_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/form_field.py
+++ b/dart/generated/models/form_field.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -34,9 +34,9 @@ class FormField:
     label: str
     default: Any
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         form_duid = self.form_duid
@@ -61,7 +61,7 @@ class FormField:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -82,7 +82,7 @@ class FormField:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -128,7 +128,7 @@ class FormField:
         return form_field
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/form_field_create.py
+++ b/dart/generated/models/form_field_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -32,9 +32,9 @@ class FormFieldCreate:
     hidden: Union[Unset, bool] = UNSET
     label: Union[Unset, str] = UNSET
     default: Union[Unset, Any] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         form_duid = self.form_duid
@@ -53,7 +53,7 @@ class FormFieldCreate:
 
         default = self.default
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -77,7 +77,7 @@ class FormFieldCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -113,7 +113,7 @@ class FormFieldCreate:
         return form_field_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/form_field_update.py
+++ b/dart/generated/models/form_field_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -32,9 +32,9 @@ class FormFieldUpdate:
     hidden: Union[Unset, bool] = UNSET
     label: Union[Unset, str] = UNSET
     default: Union[Unset, Any] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         form_duid = self.form_duid
@@ -53,7 +53,7 @@ class FormFieldUpdate:
 
         default = self.default
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -80,7 +80,7 @@ class FormFieldUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -116,7 +116,7 @@ class FormFieldUpdate:
         return form_field_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/form_update.py
+++ b/dart/generated/models/form_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -35,9 +35,9 @@ class FormUpdate:
     icon_kind: Union[Unset, IconKind] = UNSET
     icon_name_or_emoji: Union[Unset, str] = UNSET
     color_hex: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         hidden = self.hidden
@@ -58,7 +58,7 @@ class FormUpdate:
 
         color_hex = self.color_hex
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -85,7 +85,7 @@ class FormUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -126,7 +126,7 @@ class FormUpdate:
         return form_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/github_integration.py
+++ b/dart/generated/models/github_integration.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -35,9 +35,9 @@ class GithubIntegration:
     status_on_pr_draft_duid: Union[None, str]
     status_on_pr_ready_duid: Union[None, str]
     status_on_pr_merge_duid: Union[None, str]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         status = self.status.value
 
         installation_link: Union[None, str]
@@ -62,7 +62,7 @@ class GithubIntegration:
         status_on_pr_merge_duid: Union[None, str]
         status_on_pr_merge_duid = self.status_on_pr_merge_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -81,7 +81,7 @@ class GithubIntegration:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         status = GithubIntegrationTenantExtensionStatus(d.pop("status"))
 
@@ -147,7 +147,7 @@ class GithubIntegration:
         return github_integration
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/google_data.py
+++ b/dart/generated/models/google_data.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -20,9 +20,9 @@ class GoogleData:
     email: str
     picture_url: Union[None, str]
     organization_domain: Union[None, str]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         name = self.name
 
         email = self.email
@@ -33,7 +33,7 @@ class GoogleData:
         organization_domain: Union[None, str]
         organization_domain = self.organization_domain
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -47,7 +47,7 @@ class GoogleData:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         name = d.pop("name")
 
@@ -78,7 +78,7 @@ class GoogleData:
         return google_data
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/layout.py
+++ b/dart/generated/models/layout.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -31,7 +31,7 @@ class Layout:
             * `roadmap` - ROADMAP
         kind_config_map (LayoutKindConfigMap):
         filter_group (FilterGroup):
-        sorts (List['Sort']):
+        sorts (list['Sort']):
         summary_statistic_kind (SummaryStatisticKind): * `None` - NONE
             * `TotalCount` - TOTAL_COUNT
             * `IncompleteCount` - INCOMPLETE_COUNT
@@ -48,12 +48,12 @@ class Layout:
     kind: LayoutKind
     kind_config_map: "LayoutKindConfigMap"
     filter_group: "FilterGroup"
-    sorts: List["Sort"]
+    sorts: list["Sort"]
     summary_statistic_kind: SummaryStatisticKind
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         created_at = self.created_at.isoformat()
@@ -79,7 +79,7 @@ class Layout:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -99,7 +99,7 @@ class Layout:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.filter_group import FilterGroup
         from ..models.layout_kind_config_map import LayoutKindConfigMap
         from ..models.sort import Sort
@@ -151,7 +151,7 @@ class Layout:
         return layout
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/layout_config.py
+++ b/dart/generated/models/layout_config.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -20,14 +20,14 @@ class LayoutConfig:
 
     subtask_display_mode: SubtaskDisplayMode
     show_absentees: bool
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         subtask_display_mode = self.subtask_display_mode.value
 
         show_absentees = self.show_absentees
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -39,7 +39,7 @@ class LayoutConfig:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         subtask_display_mode = SubtaskDisplayMode(d.pop("subtaskDisplayMode"))
 
@@ -54,7 +54,7 @@ class LayoutConfig:
         return layout_config
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/layout_create.py
+++ b/dart/generated/models/layout_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -37,9 +37,9 @@ class LayoutCreate:
     filter_group: Union[Unset, Any] = UNSET
     sorts: Union[Unset, Any] = UNSET
     summary_statistic_kind: Union[Unset, SummaryStatisticKind] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         kind: Union[Unset, str] = UNSET
@@ -56,7 +56,7 @@ class LayoutCreate:
         if not isinstance(self.summary_statistic_kind, Unset):
             summary_statistic_kind = self.summary_statistic_kind.value
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -77,7 +77,7 @@ class LayoutCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -114,7 +114,7 @@ class LayoutCreate:
         return layout_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/layout_kind_config_map.py
+++ b/dart/generated/models/layout_kind_config_map.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -14,17 +14,17 @@ T = TypeVar("T", bound="LayoutKindConfigMap")
 class LayoutKindConfigMap:
     """ """
 
-    additional_properties: Dict[str, "LayoutConfig"] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, "LayoutConfig"] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
-        field_dict: Dict[str, Any] = {}
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
         for prop_name, prop in self.additional_properties.items():
             field_dict[prop_name] = prop.to_dict()
 
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.layout_config import LayoutConfig
 
         d = src_dict.copy()
@@ -40,7 +40,7 @@ class LayoutKindConfigMap:
         return layout_kind_config_map
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> "LayoutConfig":

--- a/dart/generated/models/layout_update.py
+++ b/dart/generated/models/layout_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -37,9 +37,9 @@ class LayoutUpdate:
     filter_group: Union[Unset, Any] = UNSET
     sorts: Union[Unset, Any] = UNSET
     summary_statistic_kind: Union[Unset, SummaryStatisticKind] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         kind: Union[Unset, str] = UNSET
@@ -56,7 +56,7 @@ class LayoutUpdate:
         if not isinstance(self.summary_statistic_kind, Unset):
             summary_statistic_kind = self.summary_statistic_kind.value
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -77,7 +77,7 @@ class LayoutUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -114,7 +114,7 @@ class LayoutUpdate:
         return layout_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/line_chart_adtl.py
+++ b/dart/generated/models/line_chart_adtl.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -16,15 +16,15 @@ class LineChartAdtl:
 
     x_property_duid: str
     group_by_property_duid: Union[None, str]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         x_property_duid = self.x_property_duid
 
         group_by_property_duid: Union[None, str]
         group_by_property_duid = self.group_by_property_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -36,7 +36,7 @@ class LineChartAdtl:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         x_property_duid = d.pop("xPropertyDuid")
 
@@ -56,7 +56,7 @@ class LineChartAdtl:
         return line_chart_adtl
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/models_response.py
+++ b/dart/generated/models/models_response.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -53,273 +53,273 @@ class ModelsResponse:
     }
 
         Attributes:
-            attachments (Union[Unset, List['Attachment']]):
-            brainstorms (Union[Unset, List['Brainstorm']]):
-            comments (Union[Unset, List['Comment']]):
-            reactions (Union[Unset, List['CommentReaction']]):
-            dartboards (Union[Unset, List['Dartboard']]):
-            dashboards (Union[Unset, List['Dashboard']]):
-            docs (Union[Unset, List['Doc']]):
-            events (Union[Unset, List['Event']]):
-            event_subscriptions (Union[Unset, List['EventSubscription']]):
-            folders (Union[Unset, List['Folder']]):
-            forms (Union[Unset, List['Form']]):
-            form_fields (Union[Unset, List['FormField']]):
-            layouts (Union[Unset, List['Layout']]):
-            notifications (Union[Unset, List['Notification']]):
-            options (Union[Unset, List['Option']]):
-            properties (Union[Unset, List['Property']]):
-            relationships (Union[Unset, List['Relationship']]):
-            relationship_kinds (Union[Unset, List['RelationshipKind']]):
-            spaces (Union[Unset, List['Space']]):
-            statuses (Union[Unset, List['Status']]):
-            tasks (Union[Unset, List['Task']]):
-            task_doc_relationships (Union[Unset, List['TaskDocRelationship']]):
-            task_kinds (Union[Unset, List['TaskKind']]):
-            links (Union[Unset, List['TaskLink']]):
-            tenants (Union[Unset, List['Tenant']]):
-            users (Union[Unset, List['User']]):
-            user_dartboard_layouts (Union[Unset, List['UserDartboardLayout']]):
-            views (Union[Unset, List['View']]):
-            webhooks (Union[Unset, List['Webhook']]):
+            attachments (Union[Unset, list['Attachment']]):
+            brainstorms (Union[Unset, list['Brainstorm']]):
+            comments (Union[Unset, list['Comment']]):
+            reactions (Union[Unset, list['CommentReaction']]):
+            dartboards (Union[Unset, list['Dartboard']]):
+            dashboards (Union[Unset, list['Dashboard']]):
+            docs (Union[Unset, list['Doc']]):
+            events (Union[Unset, list['Event']]):
+            event_subscriptions (Union[Unset, list['EventSubscription']]):
+            folders (Union[Unset, list['Folder']]):
+            forms (Union[Unset, list['Form']]):
+            form_fields (Union[Unset, list['FormField']]):
+            layouts (Union[Unset, list['Layout']]):
+            notifications (Union[Unset, list['Notification']]):
+            options (Union[Unset, list['Option']]):
+            properties (Union[Unset, list['Property']]):
+            relationships (Union[Unset, list['Relationship']]):
+            relationship_kinds (Union[Unset, list['RelationshipKind']]):
+            spaces (Union[Unset, list['Space']]):
+            statuses (Union[Unset, list['Status']]):
+            tasks (Union[Unset, list['Task']]):
+            task_doc_relationships (Union[Unset, list['TaskDocRelationship']]):
+            task_kinds (Union[Unset, list['TaskKind']]):
+            links (Union[Unset, list['TaskLink']]):
+            tenants (Union[Unset, list['Tenant']]):
+            users (Union[Unset, list['User']]):
+            user_dartboard_layouts (Union[Unset, list['UserDartboardLayout']]):
+            views (Union[Unset, list['View']]):
+            webhooks (Union[Unset, list['Webhook']]):
     """
 
-    attachments: Union[Unset, List["Attachment"]] = UNSET
-    brainstorms: Union[Unset, List["Brainstorm"]] = UNSET
-    comments: Union[Unset, List["Comment"]] = UNSET
-    reactions: Union[Unset, List["CommentReaction"]] = UNSET
-    dartboards: Union[Unset, List["Dartboard"]] = UNSET
-    dashboards: Union[Unset, List["Dashboard"]] = UNSET
-    docs: Union[Unset, List["Doc"]] = UNSET
-    events: Union[Unset, List["Event"]] = UNSET
-    event_subscriptions: Union[Unset, List["EventSubscription"]] = UNSET
-    folders: Union[Unset, List["Folder"]] = UNSET
-    forms: Union[Unset, List["Form"]] = UNSET
-    form_fields: Union[Unset, List["FormField"]] = UNSET
-    layouts: Union[Unset, List["Layout"]] = UNSET
-    notifications: Union[Unset, List["Notification"]] = UNSET
-    options: Union[Unset, List["Option"]] = UNSET
-    properties: Union[Unset, List["Property"]] = UNSET
-    relationships: Union[Unset, List["Relationship"]] = UNSET
-    relationship_kinds: Union[Unset, List["RelationshipKind"]] = UNSET
-    spaces: Union[Unset, List["Space"]] = UNSET
-    statuses: Union[Unset, List["Status"]] = UNSET
-    tasks: Union[Unset, List["Task"]] = UNSET
-    task_doc_relationships: Union[Unset, List["TaskDocRelationship"]] = UNSET
-    task_kinds: Union[Unset, List["TaskKind"]] = UNSET
-    links: Union[Unset, List["TaskLink"]] = UNSET
-    tenants: Union[Unset, List["Tenant"]] = UNSET
-    users: Union[Unset, List["User"]] = UNSET
-    user_dartboard_layouts: Union[Unset, List["UserDartboardLayout"]] = UNSET
-    views: Union[Unset, List["View"]] = UNSET
-    webhooks: Union[Unset, List["Webhook"]] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    attachments: Union[Unset, list["Attachment"]] = UNSET
+    brainstorms: Union[Unset, list["Brainstorm"]] = UNSET
+    comments: Union[Unset, list["Comment"]] = UNSET
+    reactions: Union[Unset, list["CommentReaction"]] = UNSET
+    dartboards: Union[Unset, list["Dartboard"]] = UNSET
+    dashboards: Union[Unset, list["Dashboard"]] = UNSET
+    docs: Union[Unset, list["Doc"]] = UNSET
+    events: Union[Unset, list["Event"]] = UNSET
+    event_subscriptions: Union[Unset, list["EventSubscription"]] = UNSET
+    folders: Union[Unset, list["Folder"]] = UNSET
+    forms: Union[Unset, list["Form"]] = UNSET
+    form_fields: Union[Unset, list["FormField"]] = UNSET
+    layouts: Union[Unset, list["Layout"]] = UNSET
+    notifications: Union[Unset, list["Notification"]] = UNSET
+    options: Union[Unset, list["Option"]] = UNSET
+    properties: Union[Unset, list["Property"]] = UNSET
+    relationships: Union[Unset, list["Relationship"]] = UNSET
+    relationship_kinds: Union[Unset, list["RelationshipKind"]] = UNSET
+    spaces: Union[Unset, list["Space"]] = UNSET
+    statuses: Union[Unset, list["Status"]] = UNSET
+    tasks: Union[Unset, list["Task"]] = UNSET
+    task_doc_relationships: Union[Unset, list["TaskDocRelationship"]] = UNSET
+    task_kinds: Union[Unset, list["TaskKind"]] = UNSET
+    links: Union[Unset, list["TaskLink"]] = UNSET
+    tenants: Union[Unset, list["Tenant"]] = UNSET
+    users: Union[Unset, list["User"]] = UNSET
+    user_dartboard_layouts: Union[Unset, list["UserDartboardLayout"]] = UNSET
+    views: Union[Unset, list["View"]] = UNSET
+    webhooks: Union[Unset, list["Webhook"]] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
-        attachments: Union[Unset, List[Dict[str, Any]]] = UNSET
+    def to_dict(self) -> dict[str, Any]:
+        attachments: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.attachments, Unset):
             attachments = []
             for attachments_item_data in self.attachments:
                 attachments_item = attachments_item_data.to_dict()
                 attachments.append(attachments_item)
 
-        brainstorms: Union[Unset, List[Dict[str, Any]]] = UNSET
+        brainstorms: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.brainstorms, Unset):
             brainstorms = []
             for brainstorms_item_data in self.brainstorms:
                 brainstorms_item = brainstorms_item_data.to_dict()
                 brainstorms.append(brainstorms_item)
 
-        comments: Union[Unset, List[Dict[str, Any]]] = UNSET
+        comments: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.comments, Unset):
             comments = []
             for comments_item_data in self.comments:
                 comments_item = comments_item_data.to_dict()
                 comments.append(comments_item)
 
-        reactions: Union[Unset, List[Dict[str, Any]]] = UNSET
+        reactions: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.reactions, Unset):
             reactions = []
             for reactions_item_data in self.reactions:
                 reactions_item = reactions_item_data.to_dict()
                 reactions.append(reactions_item)
 
-        dartboards: Union[Unset, List[Dict[str, Any]]] = UNSET
+        dartboards: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.dartboards, Unset):
             dartboards = []
             for dartboards_item_data in self.dartboards:
                 dartboards_item = dartboards_item_data.to_dict()
                 dartboards.append(dartboards_item)
 
-        dashboards: Union[Unset, List[Dict[str, Any]]] = UNSET
+        dashboards: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.dashboards, Unset):
             dashboards = []
             for dashboards_item_data in self.dashboards:
                 dashboards_item = dashboards_item_data.to_dict()
                 dashboards.append(dashboards_item)
 
-        docs: Union[Unset, List[Dict[str, Any]]] = UNSET
+        docs: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.docs, Unset):
             docs = []
             for docs_item_data in self.docs:
                 docs_item = docs_item_data.to_dict()
                 docs.append(docs_item)
 
-        events: Union[Unset, List[Dict[str, Any]]] = UNSET
+        events: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.events, Unset):
             events = []
             for events_item_data in self.events:
                 events_item = events_item_data.to_dict()
                 events.append(events_item)
 
-        event_subscriptions: Union[Unset, List[Dict[str, Any]]] = UNSET
+        event_subscriptions: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.event_subscriptions, Unset):
             event_subscriptions = []
             for event_subscriptions_item_data in self.event_subscriptions:
                 event_subscriptions_item = event_subscriptions_item_data.to_dict()
                 event_subscriptions.append(event_subscriptions_item)
 
-        folders: Union[Unset, List[Dict[str, Any]]] = UNSET
+        folders: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.folders, Unset):
             folders = []
             for folders_item_data in self.folders:
                 folders_item = folders_item_data.to_dict()
                 folders.append(folders_item)
 
-        forms: Union[Unset, List[Dict[str, Any]]] = UNSET
+        forms: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.forms, Unset):
             forms = []
             for forms_item_data in self.forms:
                 forms_item = forms_item_data.to_dict()
                 forms.append(forms_item)
 
-        form_fields: Union[Unset, List[Dict[str, Any]]] = UNSET
+        form_fields: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.form_fields, Unset):
             form_fields = []
             for form_fields_item_data in self.form_fields:
                 form_fields_item = form_fields_item_data.to_dict()
                 form_fields.append(form_fields_item)
 
-        layouts: Union[Unset, List[Dict[str, Any]]] = UNSET
+        layouts: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.layouts, Unset):
             layouts = []
             for layouts_item_data in self.layouts:
                 layouts_item = layouts_item_data.to_dict()
                 layouts.append(layouts_item)
 
-        notifications: Union[Unset, List[Dict[str, Any]]] = UNSET
+        notifications: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.notifications, Unset):
             notifications = []
             for notifications_item_data in self.notifications:
                 notifications_item = notifications_item_data.to_dict()
                 notifications.append(notifications_item)
 
-        options: Union[Unset, List[Dict[str, Any]]] = UNSET
+        options: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.options, Unset):
             options = []
             for options_item_data in self.options:
                 options_item = options_item_data.to_dict()
                 options.append(options_item)
 
-        properties: Union[Unset, List[Dict[str, Any]]] = UNSET
+        properties: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.properties, Unset):
             properties = []
             for properties_item_data in self.properties:
                 properties_item = properties_item_data.to_dict()
                 properties.append(properties_item)
 
-        relationships: Union[Unset, List[Dict[str, Any]]] = UNSET
+        relationships: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.relationships, Unset):
             relationships = []
             for relationships_item_data in self.relationships:
                 relationships_item = relationships_item_data.to_dict()
                 relationships.append(relationships_item)
 
-        relationship_kinds: Union[Unset, List[Dict[str, Any]]] = UNSET
+        relationship_kinds: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.relationship_kinds, Unset):
             relationship_kinds = []
             for relationship_kinds_item_data in self.relationship_kinds:
                 relationship_kinds_item = relationship_kinds_item_data.to_dict()
                 relationship_kinds.append(relationship_kinds_item)
 
-        spaces: Union[Unset, List[Dict[str, Any]]] = UNSET
+        spaces: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.spaces, Unset):
             spaces = []
             for spaces_item_data in self.spaces:
                 spaces_item = spaces_item_data.to_dict()
                 spaces.append(spaces_item)
 
-        statuses: Union[Unset, List[Dict[str, Any]]] = UNSET
+        statuses: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.statuses, Unset):
             statuses = []
             for statuses_item_data in self.statuses:
                 statuses_item = statuses_item_data.to_dict()
                 statuses.append(statuses_item)
 
-        tasks: Union[Unset, List[Dict[str, Any]]] = UNSET
+        tasks: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.tasks, Unset):
             tasks = []
             for tasks_item_data in self.tasks:
                 tasks_item = tasks_item_data.to_dict()
                 tasks.append(tasks_item)
 
-        task_doc_relationships: Union[Unset, List[Dict[str, Any]]] = UNSET
+        task_doc_relationships: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.task_doc_relationships, Unset):
             task_doc_relationships = []
             for task_doc_relationships_item_data in self.task_doc_relationships:
                 task_doc_relationships_item = task_doc_relationships_item_data.to_dict()
                 task_doc_relationships.append(task_doc_relationships_item)
 
-        task_kinds: Union[Unset, List[Dict[str, Any]]] = UNSET
+        task_kinds: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.task_kinds, Unset):
             task_kinds = []
             for task_kinds_item_data in self.task_kinds:
                 task_kinds_item = task_kinds_item_data.to_dict()
                 task_kinds.append(task_kinds_item)
 
-        links: Union[Unset, List[Dict[str, Any]]] = UNSET
+        links: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.links, Unset):
             links = []
             for links_item_data in self.links:
                 links_item = links_item_data.to_dict()
                 links.append(links_item)
 
-        tenants: Union[Unset, List[Dict[str, Any]]] = UNSET
+        tenants: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.tenants, Unset):
             tenants = []
             for tenants_item_data in self.tenants:
                 tenants_item = tenants_item_data.to_dict()
                 tenants.append(tenants_item)
 
-        users: Union[Unset, List[Dict[str, Any]]] = UNSET
+        users: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.users, Unset):
             users = []
             for users_item_data in self.users:
                 users_item = users_item_data.to_dict()
                 users.append(users_item)
 
-        user_dartboard_layouts: Union[Unset, List[Dict[str, Any]]] = UNSET
+        user_dartboard_layouts: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.user_dartboard_layouts, Unset):
             user_dartboard_layouts = []
             for user_dartboard_layouts_item_data in self.user_dartboard_layouts:
                 user_dartboard_layouts_item = user_dartboard_layouts_item_data.to_dict()
                 user_dartboard_layouts.append(user_dartboard_layouts_item)
 
-        views: Union[Unset, List[Dict[str, Any]]] = UNSET
+        views: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.views, Unset):
             views = []
             for views_item_data in self.views:
                 views_item = views_item_data.to_dict()
                 views.append(views_item)
 
-        webhooks: Union[Unset, List[Dict[str, Any]]] = UNSET
+        webhooks: Union[Unset, list[dict[str, Any]]] = UNSET
         if not isinstance(self.webhooks, Unset):
             webhooks = []
             for webhooks_item_data in self.webhooks:
                 webhooks_item = webhooks_item_data.to_dict()
                 webhooks.append(webhooks_item)
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if attachments is not UNSET:
@@ -384,7 +384,7 @@ class ModelsResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.attachment import Attachment
         from ..models.brainstorm import Brainstorm
         from ..models.comment import Comment
@@ -655,7 +655,7 @@ class ModelsResponse:
         return models_response
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/notification.py
+++ b/dart/generated/models/notification.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -32,9 +32,9 @@ class Notification:
     event: "Event"
     read: bool
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         created_at = self.created_at.isoformat()
@@ -51,7 +51,7 @@ class Notification:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -68,7 +68,7 @@ class Notification:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.event import Event
 
         d = src_dict.copy()
@@ -104,7 +104,7 @@ class Notification:
         return notification
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/notification_update.py
+++ b/dart/generated/models/notification_update.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -26,20 +26,20 @@ class NotificationUpdate:
     user_duid: Union[Unset, str] = UNSET
     event: Union[Unset, "Event"] = UNSET
     read: Union[Unset, bool] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         user_duid = self.user_duid
 
-        event: Union[Unset, Dict[str, Any]] = UNSET
+        event: Union[Unset, dict[str, Any]] = UNSET
         if not isinstance(self.event, Unset):
             event = self.event.to_dict()
 
         read = self.read
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -56,7 +56,7 @@ class NotificationUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.event import Event
 
         d = src_dict.copy()
@@ -84,7 +84,7 @@ class NotificationUpdate:
         return notification_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/notion_integration.py
+++ b/dart/generated/models/notion_integration.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -22,9 +22,9 @@ class NotionIntegration:
     status: NotionIntegrationTenantExtensionStatus
     workspace_name: Union[None, str]
     workspace_icon: Union[None, str]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         status = self.status.value
 
         workspace_name: Union[None, str]
@@ -33,7 +33,7 @@ class NotionIntegration:
         workspace_icon: Union[None, str]
         workspace_icon = self.workspace_icon
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -46,7 +46,7 @@ class NotionIntegration:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         status = NotionIntegrationTenantExtensionStatus(d.pop("status"))
 
@@ -74,7 +74,7 @@ class NotionIntegration:
         return notion_integration
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/number_chart_adtl.py
+++ b/dart/generated/models/number_chart_adtl.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Type, TypeVar, Union, cast
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..models.number_chart_aggregation import NumberChartAggregation
+from ..models.chart_aggregation import ChartAggregation
 
 T = TypeVar("T", bound="NumberChartAdtl")
 
@@ -13,15 +13,13 @@ class NumberChartAdtl:
     """
     Attributes:
         property_duid (Union[None, str]):
-        aggregation (NumberChartAggregation): * `sum` - SUM
+        aggregation (ChartAggregation): * `sum` - SUM
             * `avg` - AVG
             * `count` - COUNT
-        filter_by_value_id (Any):
     """
 
     property_duid: Union[None, str]
-    aggregation: NumberChartAggregation
-    filter_by_value_id: Any
+    aggregation: ChartAggregation
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -30,15 +28,12 @@ class NumberChartAdtl:
 
         aggregation = self.aggregation.value
 
-        filter_by_value_id = self.filter_by_value_id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "propertyDuid": property_duid,
                 "aggregation": aggregation,
-                "filterByValueId": filter_by_value_id,
             }
         )
 
@@ -55,14 +50,11 @@ class NumberChartAdtl:
 
         property_duid = _parse_property_duid(d.pop("propertyDuid"))
 
-        aggregation = NumberChartAggregation(d.pop("aggregation"))
-
-        filter_by_value_id = d.pop("filterByValueId")
+        aggregation = ChartAggregation(d.pop("aggregation"))
 
         number_chart_adtl = cls(
             property_duid=property_duid,
             aggregation=aggregation,
-            filter_by_value_id=filter_by_value_id,
         )
 
         number_chart_adtl.additional_properties = d

--- a/dart/generated/models/number_chart_adtl.py
+++ b/dart/generated/models/number_chart_adtl.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -20,15 +20,15 @@ class NumberChartAdtl:
 
     property_duid: Union[None, str]
     aggregation: ChartAggregation
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         property_duid: Union[None, str]
         property_duid = self.property_duid
 
         aggregation = self.aggregation.value
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -40,7 +40,7 @@ class NumberChartAdtl:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
 
         def _parse_property_duid(data: object) -> Union[None, str]:
@@ -61,7 +61,7 @@ class NumberChartAdtl:
         return number_chart_adtl
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/operation.py
+++ b/dart/generated/models/operation.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -165,9 +165,9 @@ class Operation:
         "WebhookCreate",
         "WebhookUpdate",
     ]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         from ..models.attachment_create import AttachmentCreate
         from ..models.attachment_update import AttachmentUpdate
         from ..models.brainstorm_create import BrainstormCreate
@@ -222,7 +222,7 @@ class Operation:
 
         model = self.model.value
 
-        data: Dict[str, Any]
+        data: dict[str, Any]
         if isinstance(self.data, AttachmentCreate):
             data = self.data.to_dict()
         elif isinstance(self.data, AttachmentUpdate):
@@ -324,7 +324,7 @@ class Operation:
         else:
             data = self.data.to_dict()
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -337,7 +337,7 @@ class Operation:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.attachment_create import AttachmentCreate
         from ..models.attachment_update import AttachmentUpdate
         from ..models.brainstorm_create import BrainstormCreate
@@ -858,7 +858,7 @@ class Operation:
         return operation
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/option.py
+++ b/dart/generated/models/option.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -26,9 +26,9 @@ class Option:
     title: str
     color_hex: str
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         property_duid = self.property_duid
@@ -46,7 +46,7 @@ class Option:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -63,7 +63,7 @@ class Option:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -102,7 +102,7 @@ class Option:
         return option
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/option_create.py
+++ b/dart/generated/models/option_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -24,9 +24,9 @@ class OptionCreate:
     title: str
     parent_duid: Union[None, Unset, str] = UNSET
     color_hex: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         property_duid = self.property_duid
@@ -41,7 +41,7 @@ class OptionCreate:
 
         color_hex = self.color_hex
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -58,7 +58,7 @@ class OptionCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -89,7 +89,7 @@ class OptionCreate:
         return option_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/option_update.py
+++ b/dart/generated/models/option_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -24,9 +24,9 @@ class OptionUpdate:
     parent_duid: Union[None, Unset, str] = UNSET
     title: Union[Unset, str] = UNSET
     color_hex: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         property_duid = self.property_duid
@@ -41,7 +41,7 @@ class OptionUpdate:
 
         color_hex = self.color_hex
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -60,7 +60,7 @@ class OptionUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -91,7 +91,7 @@ class OptionUpdate:
         return option_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_attachment_list.py
+++ b/dart/generated/models/paginated_attachment_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedAttachmentList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['Attachment']):
+        results (list['Attachment']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["Attachment"]
+    results: list["Attachment"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedAttachmentList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedAttachmentList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.attachment import Attachment
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedAttachmentList:
         return paginated_attachment_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_comment_list.py
+++ b/dart/generated/models/paginated_comment_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedCommentList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['Comment']):
+        results (list['Comment']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["Comment"]
+    results: list["Comment"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedCommentList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedCommentList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.comment import Comment
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedCommentList:
         return paginated_comment_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_comment_reaction_list.py
+++ b/dart/generated/models/paginated_comment_reaction_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedCommentReactionList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['CommentReaction']):
+        results (list['CommentReaction']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["CommentReaction"]
+    results: list["CommentReaction"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedCommentReactionList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedCommentReactionList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.comment_reaction import CommentReaction
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedCommentReactionList:
         return paginated_comment_reaction_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_dartboard_list.py
+++ b/dart/generated/models/paginated_dartboard_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedDartboardList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['Dartboard']):
+        results (list['Dartboard']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["Dartboard"]
+    results: list["Dartboard"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedDartboardList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedDartboardList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.dartboard import Dartboard
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedDartboardList:
         return paginated_dartboard_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_dashboard_list.py
+++ b/dart/generated/models/paginated_dashboard_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedDashboardList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['Dashboard']):
+        results (list['Dashboard']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["Dashboard"]
+    results: list["Dashboard"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedDashboardList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedDashboardList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.dashboard import Dashboard
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedDashboardList:
         return paginated_dashboard_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_doc_list.py
+++ b/dart/generated/models/paginated_doc_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedDocList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['Doc']):
+        results (list['Doc']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["Doc"]
+    results: list["Doc"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedDocList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedDocList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.doc import Doc
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedDocList:
         return paginated_doc_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_folder_list.py
+++ b/dart/generated/models/paginated_folder_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedFolderList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['Folder']):
+        results (list['Folder']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["Folder"]
+    results: list["Folder"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedFolderList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedFolderList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.folder import Folder
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedFolderList:
         return paginated_folder_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_form_field_list.py
+++ b/dart/generated/models/paginated_form_field_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedFormFieldList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['FormField']):
+        results (list['FormField']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["FormField"]
+    results: list["FormField"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedFormFieldList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedFormFieldList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.form_field import FormField
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedFormFieldList:
         return paginated_form_field_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_form_list.py
+++ b/dart/generated/models/paginated_form_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedFormList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['Form']):
+        results (list['Form']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["Form"]
+    results: list["Form"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedFormList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedFormList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.form import Form
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedFormList:
         return paginated_form_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_layout_list.py
+++ b/dart/generated/models/paginated_layout_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedLayoutList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['Layout']):
+        results (list['Layout']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["Layout"]
+    results: list["Layout"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedLayoutList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedLayoutList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.layout import Layout
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedLayoutList:
         return paginated_layout_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_option_list.py
+++ b/dart/generated/models/paginated_option_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedOptionList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['Option']):
+        results (list['Option']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["Option"]
+    results: list["Option"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedOptionList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedOptionList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.option import Option
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedOptionList:
         return paginated_option_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_property_list.py
+++ b/dart/generated/models/paginated_property_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedPropertyList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['Property']):
+        results (list['Property']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["Property"]
+    results: list["Property"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedPropertyList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedPropertyList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.property_ import Property
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedPropertyList:
         return paginated_property_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_relationship_kind_list.py
+++ b/dart/generated/models/paginated_relationship_kind_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedRelationshipKindList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['RelationshipKind']):
+        results (list['RelationshipKind']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["RelationshipKind"]
+    results: list["RelationshipKind"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedRelationshipKindList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedRelationshipKindList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.relationship_kind import RelationshipKind
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedRelationshipKindList:
         return paginated_relationship_kind_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_relationship_list.py
+++ b/dart/generated/models/paginated_relationship_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedRelationshipList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['Relationship']):
+        results (list['Relationship']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["Relationship"]
+    results: list["Relationship"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedRelationshipList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedRelationshipList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.relationship import Relationship
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedRelationshipList:
         return paginated_relationship_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_space_list.py
+++ b/dart/generated/models/paginated_space_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedSpaceList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['Space']):
+        results (list['Space']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["Space"]
+    results: list["Space"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedSpaceList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedSpaceList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.space import Space
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedSpaceList:
         return paginated_space_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_status_list.py
+++ b/dart/generated/models/paginated_status_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedStatusList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['Status']):
+        results (list['Status']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["Status"]
+    results: list["Status"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedStatusList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedStatusList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.status import Status
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedStatusList:
         return paginated_status_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_task_doc_relationship_list.py
+++ b/dart/generated/models/paginated_task_doc_relationship_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedTaskDocRelationshipList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['TaskDocRelationship']):
+        results (list['TaskDocRelationship']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["TaskDocRelationship"]
+    results: list["TaskDocRelationship"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedTaskDocRelationshipList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedTaskDocRelationshipList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.task_doc_relationship import TaskDocRelationship
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedTaskDocRelationshipList:
         return paginated_task_doc_relationship_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_task_kind_list.py
+++ b/dart/generated/models/paginated_task_kind_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedTaskKindList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['TaskKind']):
+        results (list['TaskKind']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["TaskKind"]
+    results: list["TaskKind"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedTaskKindList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedTaskKindList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.task_kind import TaskKind
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedTaskKindList:
         return paginated_task_kind_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_task_link_list.py
+++ b/dart/generated/models/paginated_task_link_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedTaskLinkList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['TaskLink']):
+        results (list['TaskLink']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["TaskLink"]
+    results: list["TaskLink"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedTaskLinkList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedTaskLinkList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.task_link import TaskLink
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedTaskLinkList:
         return paginated_task_link_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_task_list.py
+++ b/dart/generated/models/paginated_task_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedTaskList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['Task']):
+        results (list['Task']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["Task"]
+    results: list["Task"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedTaskList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedTaskList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.task import Task
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedTaskList:
         return paginated_task_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_tenant_list.py
+++ b/dart/generated/models/paginated_tenant_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedTenantList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['Tenant']):
+        results (list['Tenant']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["Tenant"]
+    results: list["Tenant"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedTenantList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedTenantList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.tenant import Tenant
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedTenantList:
         return paginated_tenant_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_user_dartboard_layout_list.py
+++ b/dart/generated/models/paginated_user_dartboard_layout_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedUserDartboardLayoutList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['UserDartboardLayout']):
+        results (list['UserDartboardLayout']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["UserDartboardLayout"]
+    results: list["UserDartboardLayout"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedUserDartboardLayoutList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedUserDartboardLayoutList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.user_dartboard_layout import UserDartboardLayout
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedUserDartboardLayoutList:
         return paginated_user_dartboard_layout_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_user_list.py
+++ b/dart/generated/models/paginated_user_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedUserList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['User']):
+        results (list['User']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["User"]
+    results: list["User"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedUserList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedUserList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.user import User
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedUserList:
         return paginated_user_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_view_list.py
+++ b/dart/generated/models/paginated_view_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedViewList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['View']):
+        results (list['View']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["View"]
+    results: list["View"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedViewList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedViewList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.view import View
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedViewList:
         return paginated_view_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/paginated_webhook_list.py
+++ b/dart/generated/models/paginated_webhook_list.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,18 +17,18 @@ class PaginatedWebhookList:
     """
     Attributes:
         count (int):  Example: 123.
-        results (List['Webhook']):
+        results (list['Webhook']):
         next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
         previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
     """
 
     count: int
-    results: List["Webhook"]
+    results: list["Webhook"]
     next_: Union[None, Unset, str] = UNSET
     previous: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         count = self.count
 
         results = []
@@ -48,7 +48,7 @@ class PaginatedWebhookList:
         else:
             previous = self.previous
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -64,7 +64,7 @@ class PaginatedWebhookList:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.webhook import Webhook
 
         d = src_dict.copy()
@@ -106,7 +106,7 @@ class PaginatedWebhookList:
         return paginated_webhook_list
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/pie_chart_adtl.py
+++ b/dart/generated/models/pie_chart_adtl.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -19,14 +19,14 @@ class PieChartAdtl:
 
     property_duid: str
     display_metric: PieChartDisplayMetric
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         property_duid = self.property_duid
 
         display_metric = self.display_metric.value
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -38,7 +38,7 @@ class PieChartAdtl:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         property_duid = d.pop("propertyDuid")
 
@@ -53,7 +53,7 @@ class PieChartAdtl:
         return pie_chart_adtl
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/property_.py
+++ b/dart/generated/models/property_.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -55,9 +55,9 @@ class Property:
     description: str
     adtl: Any
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         kind = self.kind.value
@@ -78,7 +78,7 @@ class Property:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -97,7 +97,7 @@ class Property:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -137,7 +137,7 @@ class Property:
         return property_
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/property_create.py
+++ b/dart/generated/models/property_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -53,9 +53,9 @@ class PropertyCreate:
     title: Union[Unset, str] = UNSET
     description: Union[Unset, str] = UNSET
     adtl: Union[Unset, Any] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         kind = self.kind.value
@@ -70,7 +70,7 @@ class PropertyCreate:
 
         adtl = self.adtl
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -91,7 +91,7 @@ class PropertyCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -121,7 +121,7 @@ class PropertyCreate:
         return property_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/property_update.py
+++ b/dart/generated/models/property_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -53,9 +53,9 @@ class PropertyUpdate:
     title: Union[Unset, str] = UNSET
     description: Union[Unset, str] = UNSET
     adtl: Union[Unset, Any] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         kind: Union[Unset, str] = UNSET
@@ -72,7 +72,7 @@ class PropertyUpdate:
 
         adtl = self.adtl
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -95,7 +95,7 @@ class PropertyUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -130,7 +130,7 @@ class PropertyUpdate:
         return property_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/relationship.py
+++ b/dart/generated/models/relationship.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -18,16 +18,16 @@ class Relationship:
     duid: str
     source_duid: str
     target_duid: str
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         source_duid = self.source_duid
 
         target_duid = self.target_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -40,7 +40,7 @@ class Relationship:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -58,7 +58,7 @@ class Relationship:
         return relationship
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/relationship_create.py
+++ b/dart/generated/models/relationship_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -24,9 +24,9 @@ class RelationshipCreate:
     kind_duid: str
     target_duid: str
     is_forward: Union[Unset, bool] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         source_duid = self.source_duid
@@ -37,7 +37,7 @@ class RelationshipCreate:
 
         is_forward = self.is_forward
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -53,7 +53,7 @@ class RelationshipCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -77,7 +77,7 @@ class RelationshipCreate:
         return relationship_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/relationship_kind.py
+++ b/dart/generated/models/relationship_kind.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -31,9 +31,9 @@ class RelationshipKind:
     forward_text: str
     backward_text: Union[None, str]
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         kind = self.kind.value
@@ -51,7 +51,7 @@ class RelationshipKind:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -68,7 +68,7 @@ class RelationshipKind:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -107,7 +107,7 @@ class RelationshipKind:
         return relationship_kind
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/relationship_kind_create.py
+++ b/dart/generated/models/relationship_kind_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -29,9 +29,9 @@ class RelationshipKindCreate:
     forward_text: str
     kind: Union[Unset, RelationshipKindKind] = UNSET
     backward_text: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         directed = self.directed
@@ -48,7 +48,7 @@ class RelationshipKindCreate:
         else:
             backward_text = self.backward_text
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -65,7 +65,7 @@ class RelationshipKindCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -101,7 +101,7 @@ class RelationshipKindCreate:
         return relationship_kind_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/relationship_kind_update.py
+++ b/dart/generated/models/relationship_kind_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -29,9 +29,9 @@ class RelationshipKindUpdate:
     directed: Union[Unset, bool] = UNSET
     forward_text: Union[Unset, str] = UNSET
     backward_text: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         kind: Union[Unset, str] = UNSET
@@ -48,7 +48,7 @@ class RelationshipKindUpdate:
         else:
             backward_text = self.backward_text
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -67,7 +67,7 @@ class RelationshipKindUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -103,7 +103,7 @@ class RelationshipKindUpdate:
         return relationship_kind_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/request_body.py
+++ b/dart/generated/models/request_body.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -14,15 +14,15 @@ T = TypeVar("T", bound="RequestBody")
 class RequestBody:
     """
     Attributes:
-        items (List['Transaction']):
+        items (list['Transaction']):
         client_duid (str):
     """
 
-    items: List["Transaction"]
+    items: list["Transaction"]
     client_duid: str
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         items = []
         for items_item_data in self.items:
             items_item = items_item_data.to_dict()
@@ -30,7 +30,7 @@ class RequestBody:
 
         client_duid = self.client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -42,7 +42,7 @@ class RequestBody:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.transaction import Transaction
 
         d = src_dict.copy()
@@ -64,7 +64,7 @@ class RequestBody:
         return request_body
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/response_body.py
+++ b/dart/generated/models/response_body.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -14,19 +14,19 @@ T = TypeVar("T", bound="ResponseBody")
 class ResponseBody:
     """
     Attributes:
-        results (List['TransactionResponse']):
+        results (list['TransactionResponse']):
     """
 
-    results: List["TransactionResponse"]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    results: list["TransactionResponse"]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         results = []
         for results_item_data in self.results:
             results_item = results_item_data.to_dict()
             results.append(results_item)
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -37,7 +37,7 @@ class ResponseBody:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.transaction_response import TransactionResponse
 
         d = src_dict.copy()
@@ -56,7 +56,7 @@ class ResponseBody:
         return response_body
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/saml_config.py
+++ b/dart/generated/models/saml_config.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -21,16 +21,16 @@ class SamlConfig:
     status: SamlConfigTenantExtensionStatus
     idp_url: str
     idp_xml: str
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         status = self.status.value
 
         idp_url = self.idp_url
 
         idp_xml = self.idp_xml
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -43,7 +43,7 @@ class SamlConfig:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         status = SamlConfigTenantExtensionStatus(d.pop("status"))
 
@@ -61,7 +61,7 @@ class SamlConfig:
         return saml_config
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/slack_integration.py
+++ b/dart/generated/models/slack_integration.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -22,9 +22,9 @@ class SlackIntegration:
     status: SlackIntegrationTenantExtensionStatus
     workspace_name: Union[None, str]
     workspace_icon: Union[None, str]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         status = self.status.value
 
         workspace_name: Union[None, str]
@@ -33,7 +33,7 @@ class SlackIntegration:
         workspace_icon: Union[None, str]
         workspace_icon = self.workspace_icon
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -46,7 +46,7 @@ class SlackIntegration:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         status = SlackIntegrationTenantExtensionStatus(d.pop("status"))
 
@@ -74,7 +74,7 @@ class SlackIntegration:
         return slack_integration
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/sort.py
+++ b/dart/generated/models/sort.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -16,14 +16,14 @@ class Sort:
 
     field: str
     is_ascending: bool
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         field = self.field
 
         is_ascending = self.is_ascending
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -35,7 +35,7 @@ class Sort:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         field = d.pop("field")
 
@@ -50,7 +50,7 @@ class Sort:
         return sort
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/space.py
+++ b/dart/generated/models/space.py
@@ -41,6 +41,8 @@ class Space:
         standup_recurs_next_at (Union[None, datetime.datetime]):
         changelog_recurrence (Union[Any, None]):
         changelog_recurs_next_at (Union[None, datetime.datetime]):
+        rollover_recurrence (Union[Any, None]):
+        rollover_recurs_next_at (Union[None, datetime.datetime]):
         updated_by_client_duid (Union[None, Unset, str]):
     """
 
@@ -63,6 +65,8 @@ class Space:
     standup_recurs_next_at: Union[None, datetime.datetime]
     changelog_recurrence: Union[Any, None]
     changelog_recurs_next_at: Union[None, datetime.datetime]
+    rollover_recurrence: Union[Any, None]
+    rollover_recurs_next_at: Union[None, datetime.datetime]
     updated_by_client_duid: Union[None, Unset, str] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -116,6 +120,15 @@ class Space:
         else:
             changelog_recurs_next_at = self.changelog_recurs_next_at
 
+        rollover_recurrence: Union[Any, None]
+        rollover_recurrence = self.rollover_recurrence
+
+        rollover_recurs_next_at: Union[None, str]
+        if isinstance(self.rollover_recurs_next_at, datetime.datetime):
+            rollover_recurs_next_at = self.rollover_recurs_next_at.isoformat()
+        else:
+            rollover_recurs_next_at = self.rollover_recurs_next_at
+
         updated_by_client_duid: Union[None, Unset, str]
         if isinstance(self.updated_by_client_duid, Unset):
             updated_by_client_duid = UNSET
@@ -145,6 +158,8 @@ class Space:
                 "standupRecursNextAt": standup_recurs_next_at,
                 "changelogRecurrence": changelog_recurrence,
                 "changelogRecursNextAt": changelog_recurs_next_at,
+                "rolloverRecurrence": rollover_recurrence,
+                "rolloverRecursNextAt": rollover_recurs_next_at,
             }
         )
         if updated_by_client_duid is not UNSET:
@@ -234,6 +249,28 @@ class Space:
 
         changelog_recurs_next_at = _parse_changelog_recurs_next_at(d.pop("changelogRecursNextAt"))
 
+        def _parse_rollover_recurrence(data: object) -> Union[Any, None]:
+            if data is None:
+                return data
+            return cast(Union[Any, None], data)
+
+        rollover_recurrence = _parse_rollover_recurrence(d.pop("rolloverRecurrence"))
+
+        def _parse_rollover_recurs_next_at(data: object) -> Union[None, datetime.datetime]:
+            if data is None:
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                rollover_recurs_next_at_type_0 = isoparse(data)
+
+                return rollover_recurs_next_at_type_0
+            except:  # noqa: E722
+                pass
+            return cast(Union[None, datetime.datetime], data)
+
+        rollover_recurs_next_at = _parse_rollover_recurs_next_at(d.pop("rolloverRecursNextAt"))
+
         def _parse_updated_by_client_duid(data: object) -> Union[None, Unset, str]:
             if data is None:
                 return data
@@ -263,6 +300,8 @@ class Space:
             standup_recurs_next_at=standup_recurs_next_at,
             changelog_recurrence=changelog_recurrence,
             changelog_recurs_next_at=changelog_recurs_next_at,
+            rollover_recurrence=rollover_recurrence,
+            rollover_recurs_next_at=rollover_recurs_next_at,
             updated_by_client_duid=updated_by_client_duid,
         )
 

--- a/dart/generated/models/space.py
+++ b/dart/generated/models/space.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -23,7 +23,7 @@ class Space:
             * `Workspace` - WORKSPACE
             * `Personal` - PERSONAL
         accessible_by_team (bool):
-        accessible_by_user_duids (List[str]):
+        accessible_by_user_duids (list[str]):
         order (str):
         title (str):
         abrev (str):
@@ -50,7 +50,7 @@ class Space:
     drafter_duid: Union[None, str]
     kind: SpaceKind
     accessible_by_team: bool
-    accessible_by_user_duids: List[str]
+    accessible_by_user_duids: list[str]
     order: str
     title: str
     abrev: str
@@ -68,9 +68,9 @@ class Space:
     rollover_recurrence: Union[Any, None]
     rollover_recurs_next_at: Union[None, datetime.datetime]
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         drafter_duid: Union[None, str]
@@ -135,7 +135,7 @@ class Space:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -168,7 +168,7 @@ class Space:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -183,7 +183,7 @@ class Space:
 
         accessible_by_team = d.pop("accessibleByTeam")
 
-        accessible_by_user_duids = cast(List[str], d.pop("accessibleByUserDuids"))
+        accessible_by_user_duids = cast(list[str], d.pop("accessibleByUserDuids"))
 
         order = d.pop("order")
 
@@ -309,7 +309,7 @@ class Space:
         return space
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/space_create.py
+++ b/dart/generated/models/space_create.py
@@ -37,6 +37,8 @@ class SpaceCreate:
         standup_recurs_next_at (Union[None, Unset, datetime.datetime]):
         changelog_recurrence (Union[Any, None, Unset]):
         changelog_recurs_next_at (Union[None, Unset, datetime.datetime]):
+        rollover_recurrence (Union[Any, None, Unset]):
+        rollover_recurs_next_at (Union[None, Unset, datetime.datetime]):
     """
 
     duid: str
@@ -57,6 +59,8 @@ class SpaceCreate:
     standup_recurs_next_at: Union[None, Unset, datetime.datetime] = UNSET
     changelog_recurrence: Union[Any, None, Unset] = UNSET
     changelog_recurs_next_at: Union[None, Unset, datetime.datetime] = UNSET
+    rollover_recurrence: Union[Any, None, Unset] = UNSET
+    rollover_recurs_next_at: Union[None, Unset, datetime.datetime] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -126,6 +130,20 @@ class SpaceCreate:
         else:
             changelog_recurs_next_at = self.changelog_recurs_next_at
 
+        rollover_recurrence: Union[Any, None, Unset]
+        if isinstance(self.rollover_recurrence, Unset):
+            rollover_recurrence = UNSET
+        else:
+            rollover_recurrence = self.rollover_recurrence
+
+        rollover_recurs_next_at: Union[None, Unset, str]
+        if isinstance(self.rollover_recurs_next_at, Unset):
+            rollover_recurs_next_at = UNSET
+        elif isinstance(self.rollover_recurs_next_at, datetime.datetime):
+            rollover_recurs_next_at = self.rollover_recurs_next_at.isoformat()
+        else:
+            rollover_recurs_next_at = self.rollover_recurs_next_at
+
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -166,6 +184,10 @@ class SpaceCreate:
             field_dict["changelogRecurrence"] = changelog_recurrence
         if changelog_recurs_next_at is not UNSET:
             field_dict["changelogRecursNextAt"] = changelog_recurs_next_at
+        if rollover_recurrence is not UNSET:
+            field_dict["rolloverRecurrence"] = rollover_recurrence
+        if rollover_recurs_next_at is not UNSET:
+            field_dict["rolloverRecursNextAt"] = rollover_recurs_next_at
 
         return field_dict
 
@@ -269,6 +291,32 @@ class SpaceCreate:
 
         changelog_recurs_next_at = _parse_changelog_recurs_next_at(d.pop("changelogRecursNextAt", UNSET))
 
+        def _parse_rollover_recurrence(data: object) -> Union[Any, None, Unset]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[Any, None, Unset], data)
+
+        rollover_recurrence = _parse_rollover_recurrence(d.pop("rolloverRecurrence", UNSET))
+
+        def _parse_rollover_recurs_next_at(data: object) -> Union[None, Unset, datetime.datetime]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                rollover_recurs_next_at_type_0 = isoparse(data)
+
+                return rollover_recurs_next_at_type_0
+            except:  # noqa: E722
+                pass
+            return cast(Union[None, Unset, datetime.datetime], data)
+
+        rollover_recurs_next_at = _parse_rollover_recurs_next_at(d.pop("rolloverRecursNextAt", UNSET))
+
         space_create = cls(
             duid=duid,
             order=order,
@@ -288,6 +336,8 @@ class SpaceCreate:
             standup_recurs_next_at=standup_recurs_next_at,
             changelog_recurrence=changelog_recurrence,
             changelog_recurs_next_at=changelog_recurs_next_at,
+            rollover_recurrence=rollover_recurrence,
+            rollover_recurs_next_at=rollover_recurs_next_at,
         )
 
         space_create.additional_properties = d

--- a/dart/generated/models/space_create.py
+++ b/dart/generated/models/space_create.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -20,7 +20,7 @@ class SpaceCreate:
         order (str):
         drafter_duid (Union[None, Unset, str]):
         accessible_by_team (Union[Unset, bool]):
-        accessible_by_user_duids (Union[Unset, List[str]]):
+        accessible_by_user_duids (Union[Unset, list[str]]):
         title (Union[Unset, str]):
         abrev (Union[Unset, str]):
         description (Union[Unset, str]):
@@ -45,7 +45,7 @@ class SpaceCreate:
     order: str
     drafter_duid: Union[None, Unset, str] = UNSET
     accessible_by_team: Union[Unset, bool] = UNSET
-    accessible_by_user_duids: Union[Unset, List[str]] = UNSET
+    accessible_by_user_duids: Union[Unset, list[str]] = UNSET
     title: Union[Unset, str] = UNSET
     abrev: Union[Unset, str] = UNSET
     description: Union[Unset, str] = UNSET
@@ -61,9 +61,9 @@ class SpaceCreate:
     changelog_recurs_next_at: Union[None, Unset, datetime.datetime] = UNSET
     rollover_recurrence: Union[Any, None, Unset] = UNSET
     rollover_recurs_next_at: Union[None, Unset, datetime.datetime] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         order = self.order
@@ -76,7 +76,7 @@ class SpaceCreate:
 
         accessible_by_team = self.accessible_by_team
 
-        accessible_by_user_duids: Union[Unset, List[str]] = UNSET
+        accessible_by_user_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.accessible_by_user_duids, Unset):
             accessible_by_user_duids = self.accessible_by_user_duids
 
@@ -144,7 +144,7 @@ class SpaceCreate:
         else:
             rollover_recurs_next_at = self.rollover_recurs_next_at
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -192,7 +192,7 @@ class SpaceCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -209,7 +209,7 @@ class SpaceCreate:
 
         accessible_by_team = d.pop("accessibleByTeam", UNSET)
 
-        accessible_by_user_duids = cast(List[str], d.pop("accessibleByUserDuids", UNSET))
+        accessible_by_user_duids = cast(list[str], d.pop("accessibleByUserDuids", UNSET))
 
         title = d.pop("title", UNSET)
 
@@ -344,7 +344,7 @@ class SpaceCreate:
         return space_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/space_update.py
+++ b/dart/generated/models/space_update.py
@@ -37,6 +37,8 @@ class SpaceUpdate:
         standup_recurs_next_at (Union[None, Unset, datetime.datetime]):
         changelog_recurrence (Union[Any, None, Unset]):
         changelog_recurs_next_at (Union[None, Unset, datetime.datetime]):
+        rollover_recurrence (Union[Any, None, Unset]):
+        rollover_recurs_next_at (Union[None, Unset, datetime.datetime]):
     """
 
     duid: str
@@ -57,6 +59,8 @@ class SpaceUpdate:
     standup_recurs_next_at: Union[None, Unset, datetime.datetime] = UNSET
     changelog_recurrence: Union[Any, None, Unset] = UNSET
     changelog_recurs_next_at: Union[None, Unset, datetime.datetime] = UNSET
+    rollover_recurrence: Union[Any, None, Unset] = UNSET
+    rollover_recurs_next_at: Union[None, Unset, datetime.datetime] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -126,6 +130,20 @@ class SpaceUpdate:
         else:
             changelog_recurs_next_at = self.changelog_recurs_next_at
 
+        rollover_recurrence: Union[Any, None, Unset]
+        if isinstance(self.rollover_recurrence, Unset):
+            rollover_recurrence = UNSET
+        else:
+            rollover_recurrence = self.rollover_recurrence
+
+        rollover_recurs_next_at: Union[None, Unset, str]
+        if isinstance(self.rollover_recurs_next_at, Unset):
+            rollover_recurs_next_at = UNSET
+        elif isinstance(self.rollover_recurs_next_at, datetime.datetime):
+            rollover_recurs_next_at = self.rollover_recurs_next_at.isoformat()
+        else:
+            rollover_recurs_next_at = self.rollover_recurs_next_at
+
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -167,6 +185,10 @@ class SpaceUpdate:
             field_dict["changelogRecurrence"] = changelog_recurrence
         if changelog_recurs_next_at is not UNSET:
             field_dict["changelogRecursNextAt"] = changelog_recurs_next_at
+        if rollover_recurrence is not UNSET:
+            field_dict["rolloverRecurrence"] = rollover_recurrence
+        if rollover_recurs_next_at is not UNSET:
+            field_dict["rolloverRecursNextAt"] = rollover_recurs_next_at
 
         return field_dict
 
@@ -270,6 +292,32 @@ class SpaceUpdate:
 
         changelog_recurs_next_at = _parse_changelog_recurs_next_at(d.pop("changelogRecursNextAt", UNSET))
 
+        def _parse_rollover_recurrence(data: object) -> Union[Any, None, Unset]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[Any, None, Unset], data)
+
+        rollover_recurrence = _parse_rollover_recurrence(d.pop("rolloverRecurrence", UNSET))
+
+        def _parse_rollover_recurs_next_at(data: object) -> Union[None, Unset, datetime.datetime]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                rollover_recurs_next_at_type_0 = isoparse(data)
+
+                return rollover_recurs_next_at_type_0
+            except:  # noqa: E722
+                pass
+            return cast(Union[None, Unset, datetime.datetime], data)
+
+        rollover_recurs_next_at = _parse_rollover_recurs_next_at(d.pop("rolloverRecursNextAt", UNSET))
+
         space_update = cls(
             duid=duid,
             drafter_duid=drafter_duid,
@@ -289,6 +337,8 @@ class SpaceUpdate:
             standup_recurs_next_at=standup_recurs_next_at,
             changelog_recurrence=changelog_recurrence,
             changelog_recurs_next_at=changelog_recurs_next_at,
+            rollover_recurrence=rollover_recurrence,
+            rollover_recurs_next_at=rollover_recurs_next_at,
         )
 
         space_update.additional_properties = d

--- a/dart/generated/models/space_update.py
+++ b/dart/generated/models/space_update.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -19,7 +19,7 @@ class SpaceUpdate:
         duid (str):
         drafter_duid (Union[None, Unset, str]):
         accessible_by_team (Union[Unset, bool]):
-        accessible_by_user_duids (Union[Unset, List[str]]):
+        accessible_by_user_duids (Union[Unset, list[str]]):
         order (Union[Unset, str]):
         title (Union[Unset, str]):
         abrev (Union[Unset, str]):
@@ -44,7 +44,7 @@ class SpaceUpdate:
     duid: str
     drafter_duid: Union[None, Unset, str] = UNSET
     accessible_by_team: Union[Unset, bool] = UNSET
-    accessible_by_user_duids: Union[Unset, List[str]] = UNSET
+    accessible_by_user_duids: Union[Unset, list[str]] = UNSET
     order: Union[Unset, str] = UNSET
     title: Union[Unset, str] = UNSET
     abrev: Union[Unset, str] = UNSET
@@ -61,9 +61,9 @@ class SpaceUpdate:
     changelog_recurs_next_at: Union[None, Unset, datetime.datetime] = UNSET
     rollover_recurrence: Union[Any, None, Unset] = UNSET
     rollover_recurs_next_at: Union[None, Unset, datetime.datetime] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         drafter_duid: Union[None, Unset, str]
@@ -74,7 +74,7 @@ class SpaceUpdate:
 
         accessible_by_team = self.accessible_by_team
 
-        accessible_by_user_duids: Union[Unset, List[str]] = UNSET
+        accessible_by_user_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.accessible_by_user_duids, Unset):
             accessible_by_user_duids = self.accessible_by_user_duids
 
@@ -144,7 +144,7 @@ class SpaceUpdate:
         else:
             rollover_recurs_next_at = self.rollover_recurs_next_at
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -193,7 +193,7 @@ class SpaceUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -208,7 +208,7 @@ class SpaceUpdate:
 
         accessible_by_team = d.pop("accessibleByTeam", UNSET)
 
-        accessible_by_user_duids = cast(List[str], d.pop("accessibleByUserDuids", UNSET))
+        accessible_by_user_duids = cast(list[str], d.pop("accessibleByUserDuids", UNSET))
 
         order = d.pop("order", UNSET)
 
@@ -345,7 +345,7 @@ class SpaceUpdate:
         return space_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/status.py
+++ b/dart/generated/models/status.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -37,9 +37,9 @@ class Status:
     color_hex: str
     description: str
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         property_duid = self.property_duid
@@ -62,7 +62,7 @@ class Status:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -82,7 +82,7 @@ class Status:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -125,7 +125,7 @@ class Status:
         return status
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/status_create.py
+++ b/dart/generated/models/status_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -35,9 +35,9 @@ class StatusCreate:
     title: Union[Unset, str] = UNSET
     color_hex: Union[Unset, str] = UNSET
     description: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         property_duid = self.property_duid
@@ -54,7 +54,7 @@ class StatusCreate:
 
         description = self.description
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -76,7 +76,7 @@ class StatusCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -109,7 +109,7 @@ class StatusCreate:
         return status_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/status_update.py
+++ b/dart/generated/models/status_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -35,9 +35,9 @@ class StatusUpdate:
     title: Union[Unset, str] = UNSET
     color_hex: Union[Unset, str] = UNSET
     description: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         property_duid = self.property_duid
@@ -56,7 +56,7 @@ class StatusUpdate:
 
         description = self.description
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -81,7 +81,7 @@ class StatusUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -119,7 +119,7 @@ class StatusUpdate:
         return status_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/table_chart_adtl.py
+++ b/dart/generated/models/table_chart_adtl.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, List, Type, TypeVar, Union, cast
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..models.chart_aggregation import ChartAggregation
+
 T = TypeVar("T", bound="TableChartAdtl")
 
 
@@ -12,10 +14,16 @@ class TableChartAdtl:
     Attributes:
         column_property_duid (str):
         row_property_duid (Union[None, str]):
+        aggregation (ChartAggregation): * `sum` - SUM
+            * `avg` - AVG
+            * `count` - COUNT
+        aggregation_property_duid (Union[None, str]):
     """
 
     column_property_duid: str
     row_property_duid: Union[None, str]
+    aggregation: ChartAggregation
+    aggregation_property_duid: Union[None, str]
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -24,12 +32,19 @@ class TableChartAdtl:
         row_property_duid: Union[None, str]
         row_property_duid = self.row_property_duid
 
+        aggregation = self.aggregation.value
+
+        aggregation_property_duid: Union[None, str]
+        aggregation_property_duid = self.aggregation_property_duid
+
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "columnPropertyDuid": column_property_duid,
                 "rowPropertyDuid": row_property_duid,
+                "aggregation": aggregation,
+                "aggregationPropertyDuid": aggregation_property_duid,
             }
         )
 
@@ -47,9 +62,20 @@ class TableChartAdtl:
 
         row_property_duid = _parse_row_property_duid(d.pop("rowPropertyDuid"))
 
+        aggregation = ChartAggregation(d.pop("aggregation"))
+
+        def _parse_aggregation_property_duid(data: object) -> Union[None, str]:
+            if data is None:
+                return data
+            return cast(Union[None, str], data)
+
+        aggregation_property_duid = _parse_aggregation_property_duid(d.pop("aggregationPropertyDuid"))
+
         table_chart_adtl = cls(
             column_property_duid=column_property_duid,
             row_property_duid=row_property_duid,
+            aggregation=aggregation,
+            aggregation_property_duid=aggregation_property_duid,
         )
 
         table_chart_adtl.additional_properties = d

--- a/dart/generated/models/table_chart_adtl.py
+++ b/dart/generated/models/table_chart_adtl.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -24,9 +24,9 @@ class TableChartAdtl:
     row_property_duid: Union[None, str]
     aggregation: ChartAggregation
     aggregation_property_duid: Union[None, str]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         column_property_duid = self.column_property_duid
 
         row_property_duid: Union[None, str]
@@ -37,7 +37,7 @@ class TableChartAdtl:
         aggregation_property_duid: Union[None, str]
         aggregation_property_duid = self.aggregation_property_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -51,7 +51,7 @@ class TableChartAdtl:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         column_property_duid = d.pop("columnPropertyDuid")
 
@@ -82,7 +82,7 @@ class TableChartAdtl:
         return table_chart_adtl
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/task.py
+++ b/dart/generated/models/task.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -64,12 +64,12 @@ class Task:
         status_duid (str):
         assigned_to_ai (bool):
         recommendation_duid (Union[None, str]):
-        assignee_duids (List[str]):
-        subscriber_duids (List[str]):
-        tag_duids (List[str]):
-        links (List['TaskLink']):
-        attachment_duids (List[str]):
-        relationships (List['Relationship']):
+        assignee_duids (list[str]):
+        subscriber_duids (list[str]):
+        tag_duids (list[str]):
+        links (list['TaskLink']):
+        attachment_duids (list[str]):
+        relationships (list['Relationship']):
         priority (Union[None, Priority]):
         size (Union[None, int]):
         start_at (Union[None, datetime.datetime]):
@@ -100,12 +100,12 @@ class Task:
     status_duid: str
     assigned_to_ai: bool
     recommendation_duid: Union[None, str]
-    assignee_duids: List[str]
-    subscriber_duids: List[str]
-    tag_duids: List[str]
-    links: List["TaskLink"]
-    attachment_duids: List[str]
-    relationships: List["Relationship"]
+    assignee_duids: list[str]
+    subscriber_duids: list[str]
+    tag_duids: list[str]
+    links: list["TaskLink"]
+    attachment_duids: list[str]
+    relationships: list["Relationship"]
     priority: Union[None, Priority]
     size: Union[None, int]
     start_at: Union[None, datetime.datetime]
@@ -116,9 +116,9 @@ class Task:
     recurs_next_at: Union[None, datetime.datetime]
     properties: "TaskProperties"
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         from ..models.task_notion_document import TaskNotionDocument
 
         duid = self.duid
@@ -152,7 +152,7 @@ class Task:
 
         description = self.description
 
-        notion_document: Union[Dict[str, Any], None]
+        notion_document: Union[None, dict[str, Any]]
         if isinstance(self.notion_document, TaskNotionDocument):
             notion_document = self.notion_document.to_dict()
         else:
@@ -229,7 +229,7 @@ class Task:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -274,7 +274,7 @@ class Task:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.relationship import Relationship
         from ..models.task_link import TaskLink
         from ..models.task_notion_document import TaskNotionDocument
@@ -350,11 +350,11 @@ class Task:
 
         recommendation_duid = _parse_recommendation_duid(d.pop("recommendationDuid"))
 
-        assignee_duids = cast(List[str], d.pop("assigneeDuids"))
+        assignee_duids = cast(list[str], d.pop("assigneeDuids"))
 
-        subscriber_duids = cast(List[str], d.pop("subscriberDuids"))
+        subscriber_duids = cast(list[str], d.pop("subscriberDuids"))
 
-        tag_duids = cast(List[str], d.pop("tagDuids"))
+        tag_duids = cast(list[str], d.pop("tagDuids"))
 
         links = []
         _links = d.pop("links")
@@ -363,7 +363,7 @@ class Task:
 
             links.append(links_item)
 
-        attachment_duids = cast(List[str], d.pop("attachmentDuids"))
+        attachment_duids = cast(list[str], d.pop("attachmentDuids"))
 
         relationships = []
         _relationships = d.pop("relationships")
@@ -515,7 +515,7 @@ class Task:
         return task
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/task_create.py
+++ b/dart/generated/models/task_create.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -58,10 +58,10 @@ class TaskCreate:
         status_duid (Union[Unset, str]):
         assigned_to_ai (Union[Unset, bool]):
         recommendation_duid (Union[None, Unset, str]):
-        assignee_duids (Union[Unset, List[str]]):
-        subscriber_duids (Union[Unset, List[str]]):
-        tag_duids (Union[Unset, List[str]]):
-        attachment_duids (Union[Unset, List[str]]):
+        assignee_duids (Union[Unset, list[str]]):
+        subscriber_duids (Union[Unset, list[str]]):
+        tag_duids (Union[Unset, list[str]]):
+        attachment_duids (Union[Unset, list[str]]):
         priority (Union[None, Priority, Unset]):
         size (Union[None, Unset, int]):
         start_at (Union[None, Unset, datetime.datetime]):
@@ -92,10 +92,10 @@ class TaskCreate:
     status_duid: Union[Unset, str] = UNSET
     assigned_to_ai: Union[Unset, bool] = UNSET
     recommendation_duid: Union[None, Unset, str] = UNSET
-    assignee_duids: Union[Unset, List[str]] = UNSET
-    subscriber_duids: Union[Unset, List[str]] = UNSET
-    tag_duids: Union[Unset, List[str]] = UNSET
-    attachment_duids: Union[Unset, List[str]] = UNSET
+    assignee_duids: Union[Unset, list[str]] = UNSET
+    subscriber_duids: Union[Unset, list[str]] = UNSET
+    tag_duids: Union[Unset, list[str]] = UNSET
+    attachment_duids: Union[Unset, list[str]] = UNSET
     priority: Union[None, Priority, Unset] = UNSET
     size: Union[None, Unset, int] = UNSET
     start_at: Union[None, Unset, datetime.datetime] = UNSET
@@ -105,9 +105,9 @@ class TaskCreate:
     recurrence: Union[Any, None, Unset] = UNSET
     recurs_next_at: Union[None, Unset, datetime.datetime] = UNSET
     properties: Union[Unset, Any] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         source_type: Union[Unset, str] = UNSET
@@ -176,19 +176,19 @@ class TaskCreate:
         else:
             recommendation_duid = self.recommendation_duid
 
-        assignee_duids: Union[Unset, List[str]] = UNSET
+        assignee_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.assignee_duids, Unset):
             assignee_duids = self.assignee_duids
 
-        subscriber_duids: Union[Unset, List[str]] = UNSET
+        subscriber_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.subscriber_duids, Unset):
             subscriber_duids = self.subscriber_duids
 
-        tag_duids: Union[Unset, List[str]] = UNSET
+        tag_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.tag_duids, Unset):
             tag_duids = self.tag_duids
 
-        attachment_duids: Union[Unset, List[str]] = UNSET
+        attachment_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.attachment_duids, Unset):
             attachment_duids = self.attachment_duids
 
@@ -248,7 +248,7 @@ class TaskCreate:
 
         properties = self.properties
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -321,7 +321,7 @@ class TaskCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -415,13 +415,13 @@ class TaskCreate:
 
         recommendation_duid = _parse_recommendation_duid(d.pop("recommendationDuid", UNSET))
 
-        assignee_duids = cast(List[str], d.pop("assigneeDuids", UNSET))
+        assignee_duids = cast(list[str], d.pop("assigneeDuids", UNSET))
 
-        subscriber_duids = cast(List[str], d.pop("subscriberDuids", UNSET))
+        subscriber_duids = cast(list[str], d.pop("subscriberDuids", UNSET))
 
-        tag_duids = cast(List[str], d.pop("tagDuids", UNSET))
+        tag_duids = cast(list[str], d.pop("tagDuids", UNSET))
 
-        attachment_duids = cast(List[str], d.pop("attachmentDuids", UNSET))
+        attachment_duids = cast(list[str], d.pop("attachmentDuids", UNSET))
 
         def _parse_priority(data: object) -> Union[None, Priority, Unset]:
             if data is None:
@@ -569,7 +569,7 @@ class TaskCreate:
         return task_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/task_doc_relationship.py
+++ b/dart/generated/models/task_doc_relationship.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -22,9 +22,9 @@ class TaskDocRelationship:
     task_duid: str
     doc_duid: str
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         task_duid = self.task_duid
@@ -37,7 +37,7 @@ class TaskDocRelationship:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -52,7 +52,7 @@ class TaskDocRelationship:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -80,7 +80,7 @@ class TaskDocRelationship:
         return task_doc_relationship
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/task_doc_relationship_create.py
+++ b/dart/generated/models/task_doc_relationship_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -18,16 +18,16 @@ class TaskDocRelationshipCreate:
     duid: str
     task_duid: str
     doc_duid: str
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         task_duid = self.task_duid
 
         doc_duid = self.doc_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -40,7 +40,7 @@ class TaskDocRelationshipCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -58,7 +58,7 @@ class TaskDocRelationshipCreate:
         return task_doc_relationship_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/task_kind.py
+++ b/dart/generated/models/task_kind.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -25,7 +25,7 @@ class TaskKind:
             * `Emoji` - EMOJI
         icon_name_or_emoji (str):
         color_hex (str):
-        hidden_status_duids (List[str]):
+        hidden_status_duids (list[str]):
         updated_by_client_duid (Union[None, Unset, str]):
     """
 
@@ -37,11 +37,11 @@ class TaskKind:
     icon_kind: IconKind
     icon_name_or_emoji: str
     color_hex: str
-    hidden_status_duids: List[str]
+    hidden_status_duids: list[str]
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         kind = self.kind.value
@@ -66,7 +66,7 @@ class TaskKind:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -87,7 +87,7 @@ class TaskKind:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -105,7 +105,7 @@ class TaskKind:
 
         color_hex = d.pop("colorHex")
 
-        hidden_status_duids = cast(List[str], d.pop("hiddenStatusDuids"))
+        hidden_status_duids = cast(list[str], d.pop("hiddenStatusDuids"))
 
         def _parse_updated_by_client_duid(data: object) -> Union[None, Unset, str]:
             if data is None:
@@ -133,7 +133,7 @@ class TaskKind:
         return task_kind
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/task_kind_create.py
+++ b/dart/generated/models/task_kind_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -25,7 +25,7 @@ class TaskKindCreate:
             * `Emoji` - EMOJI
         icon_name_or_emoji (Union[Unset, str]):
         color_hex (Union[Unset, str]):
-        hidden_status_duids (Union[Unset, List[str]]):
+        hidden_status_duids (Union[Unset, list[str]]):
     """
 
     duid: str
@@ -36,10 +36,10 @@ class TaskKindCreate:
     icon_kind: Union[Unset, IconKind] = UNSET
     icon_name_or_emoji: Union[Unset, str] = UNSET
     color_hex: Union[Unset, str] = UNSET
-    hidden_status_duids: Union[Unset, List[str]] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    hidden_status_duids: Union[Unset, list[str]] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         kind = self.kind.value
@@ -58,11 +58,11 @@ class TaskKindCreate:
 
         color_hex = self.color_hex
 
-        hidden_status_duids: Union[Unset, List[str]] = UNSET
+        hidden_status_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.hidden_status_duids, Unset):
             hidden_status_duids = self.hidden_status_duids
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -87,7 +87,7 @@ class TaskKindCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -110,7 +110,7 @@ class TaskKindCreate:
 
         color_hex = d.pop("colorHex", UNSET)
 
-        hidden_status_duids = cast(List[str], d.pop("hiddenStatusDuids", UNSET))
+        hidden_status_duids = cast(list[str], d.pop("hiddenStatusDuids", UNSET))
 
         task_kind_create = cls(
             duid=duid,
@@ -128,7 +128,7 @@ class TaskKindCreate:
         return task_kind_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/task_kind_update.py
+++ b/dart/generated/models/task_kind_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -25,7 +25,7 @@ class TaskKindUpdate:
             * `Emoji` - EMOJI
         icon_name_or_emoji (Union[Unset, str]):
         color_hex (Union[Unset, str]):
-        hidden_status_duids (Union[Unset, List[str]]):
+        hidden_status_duids (Union[Unset, list[str]]):
     """
 
     duid: str
@@ -36,10 +36,10 @@ class TaskKindUpdate:
     icon_kind: Union[Unset, IconKind] = UNSET
     icon_name_or_emoji: Union[Unset, str] = UNSET
     color_hex: Union[Unset, str] = UNSET
-    hidden_status_duids: Union[Unset, List[str]] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    hidden_status_duids: Union[Unset, list[str]] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         kind: Union[Unset, str] = UNSET
@@ -60,11 +60,11 @@ class TaskKindUpdate:
 
         color_hex = self.color_hex
 
-        hidden_status_duids: Union[Unset, List[str]] = UNSET
+        hidden_status_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.hidden_status_duids, Unset):
             hidden_status_duids = self.hidden_status_duids
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -91,7 +91,7 @@ class TaskKindUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -119,7 +119,7 @@ class TaskKindUpdate:
 
         color_hex = d.pop("colorHex", UNSET)
 
-        hidden_status_duids = cast(List[str], d.pop("hiddenStatusDuids", UNSET))
+        hidden_status_duids = cast(list[str], d.pop("hiddenStatusDuids", UNSET))
 
         task_kind_update = cls(
             duid=duid,
@@ -137,7 +137,7 @@ class TaskKindUpdate:
         return task_kind_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/task_link.py
+++ b/dart/generated/models/task_link.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -39,9 +39,9 @@ class TaskLink:
     title: Union[None, str]
     icon_url: Union[None, str]
     adtl: Any
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         order = self.order
@@ -58,7 +58,7 @@ class TaskLink:
 
         adtl = self.adtl
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -75,7 +75,7 @@ class TaskLink:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -115,7 +115,7 @@ class TaskLink:
         return task_link
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/task_link_create.py
+++ b/dart/generated/models/task_link_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -40,9 +40,9 @@ class TaskLinkCreate:
     kind: Union[Unset, TaskLinkKind] = UNSET
     title: Union[None, Unset, str] = UNSET
     icon_url: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         task_duid = self.task_duid
@@ -67,7 +67,7 @@ class TaskLinkCreate:
         else:
             icon_url = self.icon_url
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -87,7 +87,7 @@ class TaskLinkCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -136,7 +136,7 @@ class TaskLinkCreate:
         return task_link_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/task_link_update.py
+++ b/dart/generated/models/task_link_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -40,9 +40,9 @@ class TaskLinkUpdate:
     url: Union[Unset, str] = UNSET
     title: Union[None, Unset, str] = UNSET
     icon_url: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         task_duid = self.task_duid
@@ -67,7 +67,7 @@ class TaskLinkUpdate:
         else:
             icon_url = self.icon_url
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -90,7 +90,7 @@ class TaskLinkUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -139,7 +139,7 @@ class TaskLinkUpdate:
         return task_link_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/task_notion_document.py
+++ b/dart/generated/models/task_notion_document.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -34,9 +34,9 @@ class TaskNotionDocument:
     page_map: Union["TaskNotionDocumentPageMapType0", None]
     block_map: Union["TaskNotionDocumentBlockMapType0", None]
     block_children_map: Union["TaskNotionDocumentBlockChildrenMapType0", None]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         from ..models.task_notion_document_block_children_map_type_0 import TaskNotionDocumentBlockChildrenMapType0
         from ..models.task_notion_document_block_map_type_0 import TaskNotionDocumentBlockMapType0
         from ..models.task_notion_document_page_map_type_0 import TaskNotionDocumentPageMapType0
@@ -54,25 +54,25 @@ class TaskNotionDocument:
         else:
             last_refresh_at = self.last_refresh_at
 
-        page_map: Union[Dict[str, Any], None]
+        page_map: Union[None, dict[str, Any]]
         if isinstance(self.page_map, TaskNotionDocumentPageMapType0):
             page_map = self.page_map.to_dict()
         else:
             page_map = self.page_map
 
-        block_map: Union[Dict[str, Any], None]
+        block_map: Union[None, dict[str, Any]]
         if isinstance(self.block_map, TaskNotionDocumentBlockMapType0):
             block_map = self.block_map.to_dict()
         else:
             block_map = self.block_map
 
-        block_children_map: Union[Dict[str, Any], None]
+        block_children_map: Union[None, dict[str, Any]]
         if isinstance(self.block_children_map, TaskNotionDocumentBlockChildrenMapType0):
             block_children_map = self.block_children_map.to_dict()
         else:
             block_children_map = self.block_children_map
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -89,7 +89,7 @@ class TaskNotionDocument:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.task_notion_document_block_children_map_type_0 import TaskNotionDocumentBlockChildrenMapType0
         from ..models.task_notion_document_block_map_type_0 import TaskNotionDocumentBlockMapType0
         from ..models.task_notion_document_page_map_type_0 import TaskNotionDocumentPageMapType0
@@ -180,7 +180,7 @@ class TaskNotionDocument:
         return task_notion_document
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/task_notion_document_block_children_map_type_0.py
+++ b/dart/generated/models/task_notion_document_block_children_map_type_0.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -10,16 +10,16 @@ T = TypeVar("T", bound="TaskNotionDocumentBlockChildrenMapType0")
 class TaskNotionDocumentBlockChildrenMapType0:
     """ """
 
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
-        field_dict: Dict[str, Any] = {}
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         task_notion_document_block_children_map_type_0 = cls()
 
@@ -27,7 +27,7 @@ class TaskNotionDocumentBlockChildrenMapType0:
         return task_notion_document_block_children_map_type_0
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/task_notion_document_block_map_type_0.py
+++ b/dart/generated/models/task_notion_document_block_map_type_0.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -10,16 +10,16 @@ T = TypeVar("T", bound="TaskNotionDocumentBlockMapType0")
 class TaskNotionDocumentBlockMapType0:
     """ """
 
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
-        field_dict: Dict[str, Any] = {}
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         task_notion_document_block_map_type_0 = cls()
 
@@ -27,7 +27,7 @@ class TaskNotionDocumentBlockMapType0:
         return task_notion_document_block_map_type_0
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/task_notion_document_page_map_type_0.py
+++ b/dart/generated/models/task_notion_document_page_map_type_0.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -10,16 +10,16 @@ T = TypeVar("T", bound="TaskNotionDocumentPageMapType0")
 class TaskNotionDocumentPageMapType0:
     """ """
 
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
-        field_dict: Dict[str, Any] = {}
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         task_notion_document_page_map_type_0 = cls()
 
@@ -27,7 +27,7 @@ class TaskNotionDocumentPageMapType0:
         return task_notion_document_page_map_type_0
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/task_properties.py
+++ b/dart/generated/models/task_properties.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -10,16 +10,16 @@ T = TypeVar("T", bound="TaskProperties")
 class TaskProperties:
     """ """
 
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
-        field_dict: Dict[str, Any] = {}
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         task_properties = cls()
 
@@ -27,7 +27,7 @@ class TaskProperties:
         return task_properties
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/task_update.py
+++ b/dart/generated/models/task_update.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -58,10 +58,10 @@ class TaskUpdate:
         status_duid (Union[Unset, str]):
         assigned_to_ai (Union[Unset, bool]):
         recommendation_duid (Union[None, Unset, str]):
-        assignee_duids (Union[Unset, List[str]]):
-        subscriber_duids (Union[Unset, List[str]]):
-        tag_duids (Union[Unset, List[str]]):
-        attachment_duids (Union[Unset, List[str]]):
+        assignee_duids (Union[Unset, list[str]]):
+        subscriber_duids (Union[Unset, list[str]]):
+        tag_duids (Union[Unset, list[str]]):
+        attachment_duids (Union[Unset, list[str]]):
         priority (Union[None, Priority, Unset]):
         size (Union[None, Unset, int]):
         start_at (Union[None, Unset, datetime.datetime]):
@@ -92,10 +92,10 @@ class TaskUpdate:
     status_duid: Union[Unset, str] = UNSET
     assigned_to_ai: Union[Unset, bool] = UNSET
     recommendation_duid: Union[None, Unset, str] = UNSET
-    assignee_duids: Union[Unset, List[str]] = UNSET
-    subscriber_duids: Union[Unset, List[str]] = UNSET
-    tag_duids: Union[Unset, List[str]] = UNSET
-    attachment_duids: Union[Unset, List[str]] = UNSET
+    assignee_duids: Union[Unset, list[str]] = UNSET
+    subscriber_duids: Union[Unset, list[str]] = UNSET
+    tag_duids: Union[Unset, list[str]] = UNSET
+    attachment_duids: Union[Unset, list[str]] = UNSET
     priority: Union[None, Priority, Unset] = UNSET
     size: Union[None, Unset, int] = UNSET
     start_at: Union[None, Unset, datetime.datetime] = UNSET
@@ -105,9 +105,9 @@ class TaskUpdate:
     recurrence: Union[Any, None, Unset] = UNSET
     recurs_next_at: Union[None, Unset, datetime.datetime] = UNSET
     properties: Union[Unset, Any] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         source_type: Union[Unset, str] = UNSET
@@ -176,19 +176,19 @@ class TaskUpdate:
         else:
             recommendation_duid = self.recommendation_duid
 
-        assignee_duids: Union[Unset, List[str]] = UNSET
+        assignee_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.assignee_duids, Unset):
             assignee_duids = self.assignee_duids
 
-        subscriber_duids: Union[Unset, List[str]] = UNSET
+        subscriber_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.subscriber_duids, Unset):
             subscriber_duids = self.subscriber_duids
 
-        tag_duids: Union[Unset, List[str]] = UNSET
+        tag_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.tag_duids, Unset):
             tag_duids = self.tag_duids
 
-        attachment_duids: Union[Unset, List[str]] = UNSET
+        attachment_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.attachment_duids, Unset):
             attachment_duids = self.attachment_duids
 
@@ -248,7 +248,7 @@ class TaskUpdate:
 
         properties = self.properties
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -321,7 +321,7 @@ class TaskUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -415,13 +415,13 @@ class TaskUpdate:
 
         recommendation_duid = _parse_recommendation_duid(d.pop("recommendationDuid", UNSET))
 
-        assignee_duids = cast(List[str], d.pop("assigneeDuids", UNSET))
+        assignee_duids = cast(list[str], d.pop("assigneeDuids", UNSET))
 
-        subscriber_duids = cast(List[str], d.pop("subscriberDuids", UNSET))
+        subscriber_duids = cast(list[str], d.pop("subscriberDuids", UNSET))
 
-        tag_duids = cast(List[str], d.pop("tagDuids", UNSET))
+        tag_duids = cast(list[str], d.pop("tagDuids", UNSET))
 
-        attachment_duids = cast(List[str], d.pop("attachmentDuids", UNSET))
+        attachment_duids = cast(list[str], d.pop("attachmentDuids", UNSET))
 
         def _parse_priority(data: object) -> Union[None, Priority, Unset]:
             if data is None:
@@ -569,7 +569,7 @@ class TaskUpdate:
         return task_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/tenant.py
+++ b/dart/generated/models/tenant.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -74,9 +74,9 @@ class Tenant:
     discord_integration: Union["DiscordIntegration", None]
     github_integration: Union["GithubIntegration", None]
     zapier_integration: Union["ZapierIntegration", None]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         from ..models.discord_integration import DiscordIntegration
         from ..models.github_integration import GithubIntegration
         from ..models.notion_integration import NotionIntegration
@@ -121,43 +121,43 @@ class Tenant:
 
         webhook_secret = self.webhook_secret
 
-        saml_config: Union[Dict[str, Any], None]
+        saml_config: Union[None, dict[str, Any]]
         if isinstance(self.saml_config, SamlConfig):
             saml_config = self.saml_config.to_dict()
         else:
             saml_config = self.saml_config
 
-        notion_integration: Union[Dict[str, Any], None]
+        notion_integration: Union[None, dict[str, Any]]
         if isinstance(self.notion_integration, NotionIntegration):
             notion_integration = self.notion_integration.to_dict()
         else:
             notion_integration = self.notion_integration
 
-        slack_integration: Union[Dict[str, Any], None]
+        slack_integration: Union[None, dict[str, Any]]
         if isinstance(self.slack_integration, SlackIntegration):
             slack_integration = self.slack_integration.to_dict()
         else:
             slack_integration = self.slack_integration
 
-        discord_integration: Union[Dict[str, Any], None]
+        discord_integration: Union[None, dict[str, Any]]
         if isinstance(self.discord_integration, DiscordIntegration):
             discord_integration = self.discord_integration.to_dict()
         else:
             discord_integration = self.discord_integration
 
-        github_integration: Union[Dict[str, Any], None]
+        github_integration: Union[None, dict[str, Any]]
         if isinstance(self.github_integration, GithubIntegration):
             github_integration = self.github_integration.to_dict()
         else:
             github_integration = self.github_integration
 
-        zapier_integration: Union[Dict[str, Any], None]
+        zapier_integration: Union[None, dict[str, Any]]
         if isinstance(self.zapier_integration, ZapierIntegration):
             zapier_integration = self.zapier_integration.to_dict()
         else:
             zapier_integration = self.zapier_integration
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -191,7 +191,7 @@ class Tenant:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.discord_integration import DiscordIntegration
         from ..models.github_integration import GithubIntegration
         from ..models.notion_integration import NotionIntegration
@@ -362,7 +362,7 @@ class Tenant:
         return tenant
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/tenant_update.py
+++ b/dart/generated/models/tenant_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -38,9 +38,9 @@ class TenantUpdate:
     update_blockee_dates_on_update_blocker_due_date: Union[Unset, bool] = UNSET
     webhook_enabled: Union[Unset, bool] = UNSET
     webhook_secret: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         name = self.name
 
         timezone = self.timezone
@@ -65,7 +65,7 @@ class TenantUpdate:
 
         webhook_secret = self.webhook_secret
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if name is not UNSET:
@@ -96,7 +96,7 @@ class TenantUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         name = d.pop("name", UNSET)
 
@@ -141,7 +141,7 @@ class TenantUpdate:
         return tenant_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/transaction.py
+++ b/dart/generated/models/transaction.py
@@ -26,6 +26,7 @@ class Transaction:
             * `comment_reaction_create` - COMMENT_REACTION_CREATE
             * `comment_reaction_delete` - COMMENT_REACTION_DELETE
             * `sprint_rollover` - SPRINT_ROLLOVER
+            * `undo_sprint_rollover` - UNDO_SPRINT_ROLLOVER
             * `dartboard_create` - DARTBOARD_CREATE
             * `dartboard_delete` - DARTBOARD_DELETE
             * `dartboard_update` - DARTBOARD_UPDATE

--- a/dart/generated/models/transaction.py
+++ b/dart/generated/models/transaction.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -84,15 +84,15 @@ class Transaction:
             * `webhook_create` - WEBHOOK_CREATE
             * `webhook_delete` - WEBHOOK_DELETE
             * `webhook_update` - WEBHOOK_UPDATE
-        operations (List['Operation']):
+        operations (list['Operation']):
     """
 
     duid: str
     kind: TransactionKind
-    operations: List["Operation"]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    operations: list["Operation"]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         kind = self.kind.value
@@ -102,7 +102,7 @@ class Transaction:
             operations_item = operations_item_data.to_dict()
             operations.append(operations_item)
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -115,7 +115,7 @@ class Transaction:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.operation import Operation
 
         d = src_dict.copy()
@@ -140,7 +140,7 @@ class Transaction:
         return transaction
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/transaction_kind.py
+++ b/dart/generated/models/transaction_kind.py
@@ -58,6 +58,7 @@ class TransactionKind(str, Enum):
     TASK_RENAME = "task_rename"
     TASK_UPDATE = "task_update"
     TENANT_UPDATE = "tenant_update"
+    UNDO_SPRINT_ROLLOVER = "undo_sprint_rollover"
     USER_DARTBOARD_LAYOUT_CREATE = "user_dartboard_layout_create"
     USER_DARTBOARD_LAYOUT_DELETE = "user_dartboard_layout_delete"
     USER_DARTBOARD_LAYOUT_UPDATE = "user_dartboard_layout_update"

--- a/dart/generated/models/transaction_response.py
+++ b/dart/generated/models/transaction_response.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -32,9 +32,9 @@ class TransactionResponse:
     success: bool
     message: str
     models: "ModelsResponse"
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         success = self.success
@@ -43,7 +43,7 @@ class TransactionResponse:
 
         models = self.models.to_dict()
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -57,7 +57,7 @@ class TransactionResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.models_response import ModelsResponse
 
         d = src_dict.copy()
@@ -80,7 +80,7 @@ class TransactionResponse:
         return transaction_response
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/user.py
+++ b/dart/generated/models/user.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -66,9 +66,9 @@ class User:
     auth_token: Union[None, str]
     google_data: Union["GoogleData", None]
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         from ..models.google_data import GoogleData
 
         duid = self.duid
@@ -101,7 +101,7 @@ class User:
         auth_token: Union[None, str]
         auth_token = self.auth_token
 
-        google_data: Union[Dict[str, Any], None]
+        google_data: Union[None, dict[str, Any]]
         if isinstance(self.google_data, GoogleData):
             google_data = self.google_data.to_dict()
         else:
@@ -113,7 +113,7 @@ class User:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -140,7 +140,7 @@ class User:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.google_data import GoogleData
 
         d = src_dict.copy()
@@ -229,7 +229,7 @@ class User:
         return user
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/user_dartboard_layout.py
+++ b/dart/generated/models/user_dartboard_layout.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -16,14 +16,14 @@ class UserDartboardLayout:
 
     user_duid: str
     layout_duid: str
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         user_duid = self.user_duid
 
         layout_duid = self.layout_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -35,7 +35,7 @@ class UserDartboardLayout:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         user_duid = d.pop("userDuid")
 
@@ -50,7 +50,7 @@ class UserDartboardLayout:
         return user_dartboard_layout
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/user_dartboard_layout_create.py
+++ b/dart/generated/models/user_dartboard_layout_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -18,16 +18,16 @@ class UserDartboardLayoutCreate:
     user_duid: str
     dartboard_duid: str
     layout_duid: str
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         user_duid = self.user_duid
 
         dartboard_duid = self.dartboard_duid
 
         layout_duid = self.layout_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -40,7 +40,7 @@ class UserDartboardLayoutCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         user_duid = d.pop("userDuid")
 
@@ -58,7 +58,7 @@ class UserDartboardLayoutCreate:
         return user_dartboard_layout_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/user_update.py
+++ b/dart/generated/models/user_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -50,9 +50,9 @@ class UserUpdate:
     notification_in_app: Union[Unset, bool] = UNSET
     notification_email: Union[Unset, bool] = UNSET
     notification_slack: Union[Unset, bool] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         role: Union[Unset, str] = UNSET
@@ -89,7 +89,7 @@ class UserUpdate:
 
         notification_slack = self.notification_slack
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -126,7 +126,7 @@ class UserUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -194,7 +194,7 @@ class UserUpdate:
         return user_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/user_update.py
+++ b/dart/generated/models/user_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, Dict, List, Type, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -26,6 +26,7 @@ class UserUpdate:
             * `Dark` - DARK
         color_hex (Union[Unset, str]):
         open_in_native_app (Union[Unset, bool]):
+        last_url_path (Union[None, Unset, str]):
         first_day_of_week (Union[Unset, int]):
         sections (Union[Unset, Any]):
         layout (Union[Unset, Any]):
@@ -41,6 +42,7 @@ class UserUpdate:
     theme: Union[Unset, Theme] = UNSET
     color_hex: Union[Unset, str] = UNSET
     open_in_native_app: Union[Unset, bool] = UNSET
+    last_url_path: Union[None, Unset, str] = UNSET
     first_day_of_week: Union[Unset, int] = UNSET
     sections: Union[Unset, Any] = UNSET
     layout: Union[Unset, Any] = UNSET
@@ -66,6 +68,12 @@ class UserUpdate:
         color_hex = self.color_hex
 
         open_in_native_app = self.open_in_native_app
+
+        last_url_path: Union[None, Unset, str]
+        if isinstance(self.last_url_path, Unset):
+            last_url_path = UNSET
+        else:
+            last_url_path = self.last_url_path
 
         first_day_of_week = self.first_day_of_week
 
@@ -98,6 +106,8 @@ class UserUpdate:
             field_dict["colorHex"] = color_hex
         if open_in_native_app is not UNSET:
             field_dict["openInNativeApp"] = open_in_native_app
+        if last_url_path is not UNSET:
+            field_dict["lastUrlPath"] = last_url_path
         if first_day_of_week is not UNSET:
             field_dict["firstDayOfWeek"] = first_day_of_week
         if sections is not UNSET:
@@ -140,6 +150,15 @@ class UserUpdate:
 
         open_in_native_app = d.pop("openInNativeApp", UNSET)
 
+        def _parse_last_url_path(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        last_url_path = _parse_last_url_path(d.pop("lastUrlPath", UNSET))
+
         first_day_of_week = d.pop("firstDayOfWeek", UNSET)
 
         sections = d.pop("sections", UNSET)
@@ -161,6 +180,7 @@ class UserUpdate:
             theme=theme,
             color_hex=color_hex,
             open_in_native_app=open_in_native_app,
+            last_url_path=last_url_path,
             first_day_of_week=first_day_of_week,
             sections=sections,
             layout=layout,

--- a/dart/generated/models/validation_error_response.py
+++ b/dart/generated/models/validation_error_response.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -18,12 +18,12 @@ class ValidationErrorResponse:
     """
 
     items: "ValidationErrorResponseItems"
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         items = self.items.to_dict()
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -34,7 +34,7 @@ class ValidationErrorResponse:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         from ..models.validation_error_response_items import ValidationErrorResponseItems
 
         d = src_dict.copy()
@@ -48,7 +48,7 @@ class ValidationErrorResponse:
         return validation_error_response
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/validation_error_response_items.py
+++ b/dart/generated/models/validation_error_response_items.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -10,16 +10,16 @@ T = TypeVar("T", bound="ValidationErrorResponseItems")
 class ValidationErrorResponseItems:
     """ """
 
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
-        field_dict: Dict[str, Any] = {}
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
 
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         validation_error_response_items = cls()
 
@@ -27,7 +27,7 @@ class ValidationErrorResponseItems:
         return validation_error_response_items
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/view.py
+++ b/dart/generated/models/view.py
@@ -35,6 +35,7 @@ class View:
         always_shown_property_duids (List[str]):
         always_hidden_property_duids (List[str]):
         property_order_duids (List[str]):
+        property_width_map (Any):
         updated_by_client_duid (Union[None, Unset, str]):
     """
 
@@ -54,6 +55,7 @@ class View:
     always_shown_property_duids: List[str]
     always_hidden_property_duids: List[str]
     property_order_duids: List[str]
+    property_width_map: Any
     updated_by_client_duid: Union[None, Unset, str] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -90,6 +92,8 @@ class View:
 
         property_order_duids = self.property_order_duids
 
+        property_width_map = self.property_width_map
+
         updated_by_client_duid: Union[None, Unset, str]
         if isinstance(self.updated_by_client_duid, Unset):
             updated_by_client_duid = UNSET
@@ -116,6 +120,7 @@ class View:
                 "alwaysShownPropertyDuids": always_shown_property_duids,
                 "alwaysHiddenPropertyDuids": always_hidden_property_duids,
                 "propertyOrderDuids": property_order_duids,
+                "propertyWidthMap": property_width_map,
             }
         )
         if updated_by_client_duid is not UNSET:
@@ -158,6 +163,8 @@ class View:
 
         property_order_duids = cast(List[str], d.pop("propertyOrderDuids"))
 
+        property_width_map = d.pop("propertyWidthMap")
+
         def _parse_updated_by_client_duid(data: object) -> Union[None, Unset, str]:
             if data is None:
                 return data
@@ -184,6 +191,7 @@ class View:
             always_shown_property_duids=always_shown_property_duids,
             always_hidden_property_duids=always_hidden_property_duids,
             property_order_duids=property_order_duids,
+            property_width_map=property_width_map,
             updated_by_client_duid=updated_by_client_duid,
         )
 

--- a/dart/generated/models/view.py
+++ b/dart/generated/models/view.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -20,7 +20,7 @@ class View:
             * `Trash` - TRASH
             * `My tasks` - MY_TASKS
         accessible_by_team (bool):
-        accessible_by_user_duids (List[str]):
+        accessible_by_user_duids (list[str]):
         public (bool):
         order (str):
         title (str):
@@ -31,10 +31,10 @@ class View:
         icon_name_or_emoji (str):
         color_hex (str):
         layout_duid (str):
-        favorited_by_user_duids (List[str]):
-        always_shown_property_duids (List[str]):
-        always_hidden_property_duids (List[str]):
-        property_order_duids (List[str]):
+        favorited_by_user_duids (list[str]):
+        always_shown_property_duids (list[str]):
+        always_hidden_property_duids (list[str]):
+        property_order_duids (list[str]):
         property_width_map (Any):
         updated_by_client_duid (Union[None, Unset, str]):
     """
@@ -42,7 +42,7 @@ class View:
     duid: str
     kind: ViewKind
     accessible_by_team: bool
-    accessible_by_user_duids: List[str]
+    accessible_by_user_duids: list[str]
     public: bool
     order: str
     title: str
@@ -51,15 +51,15 @@ class View:
     icon_name_or_emoji: str
     color_hex: str
     layout_duid: str
-    favorited_by_user_duids: List[str]
-    always_shown_property_duids: List[str]
-    always_hidden_property_duids: List[str]
-    property_order_duids: List[str]
+    favorited_by_user_duids: list[str]
+    always_shown_property_duids: list[str]
+    always_hidden_property_duids: list[str]
+    property_order_duids: list[str]
     property_width_map: Any
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         kind = self.kind.value
@@ -100,7 +100,7 @@ class View:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -129,7 +129,7 @@ class View:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -137,7 +137,7 @@ class View:
 
         accessible_by_team = d.pop("accessibleByTeam")
 
-        accessible_by_user_duids = cast(List[str], d.pop("accessibleByUserDuids"))
+        accessible_by_user_duids = cast(list[str], d.pop("accessibleByUserDuids"))
 
         public = d.pop("public")
 
@@ -155,13 +155,13 @@ class View:
 
         layout_duid = d.pop("layoutDuid")
 
-        favorited_by_user_duids = cast(List[str], d.pop("favoritedByUserDuids"))
+        favorited_by_user_duids = cast(list[str], d.pop("favoritedByUserDuids"))
 
-        always_shown_property_duids = cast(List[str], d.pop("alwaysShownPropertyDuids"))
+        always_shown_property_duids = cast(list[str], d.pop("alwaysShownPropertyDuids"))
 
-        always_hidden_property_duids = cast(List[str], d.pop("alwaysHiddenPropertyDuids"))
+        always_hidden_property_duids = cast(list[str], d.pop("alwaysHiddenPropertyDuids"))
 
-        property_order_duids = cast(List[str], d.pop("propertyOrderDuids"))
+        property_order_duids = cast(list[str], d.pop("propertyOrderDuids"))
 
         property_width_map = d.pop("propertyWidthMap")
 
@@ -199,7 +199,7 @@ class View:
         return view
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/view_create.py
+++ b/dart/generated/models/view_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -17,7 +17,7 @@ class ViewCreate:
         order (str):
         layout_duid (str):
         accessible_by_team (Union[Unset, bool]):
-        accessible_by_user_duids (Union[Unset, List[str]]):
+        accessible_by_user_duids (Union[Unset, list[str]]):
         public (Union[Unset, bool]):
         title (Union[Unset, str]):
         description (Union[Unset, str]):
@@ -26,10 +26,10 @@ class ViewCreate:
             * `Emoji` - EMOJI
         icon_name_or_emoji (Union[Unset, str]):
         color_hex (Union[Unset, str]):
-        favorited_by_user_duids (Union[Unset, List[str]]):
-        always_shown_property_duids (Union[Unset, List[str]]):
-        always_hidden_property_duids (Union[Unset, List[str]]):
-        property_order_duids (Union[Unset, List[str]]):
+        favorited_by_user_duids (Union[Unset, list[str]]):
+        always_shown_property_duids (Union[Unset, list[str]]):
+        always_hidden_property_duids (Union[Unset, list[str]]):
+        property_order_duids (Union[Unset, list[str]]):
         property_width_map (Union[Unset, Any]):
     """
 
@@ -37,21 +37,21 @@ class ViewCreate:
     order: str
     layout_duid: str
     accessible_by_team: Union[Unset, bool] = UNSET
-    accessible_by_user_duids: Union[Unset, List[str]] = UNSET
+    accessible_by_user_duids: Union[Unset, list[str]] = UNSET
     public: Union[Unset, bool] = UNSET
     title: Union[Unset, str] = UNSET
     description: Union[Unset, str] = UNSET
     icon_kind: Union[Unset, IconKind] = UNSET
     icon_name_or_emoji: Union[Unset, str] = UNSET
     color_hex: Union[Unset, str] = UNSET
-    favorited_by_user_duids: Union[Unset, List[str]] = UNSET
-    always_shown_property_duids: Union[Unset, List[str]] = UNSET
-    always_hidden_property_duids: Union[Unset, List[str]] = UNSET
-    property_order_duids: Union[Unset, List[str]] = UNSET
+    favorited_by_user_duids: Union[Unset, list[str]] = UNSET
+    always_shown_property_duids: Union[Unset, list[str]] = UNSET
+    always_hidden_property_duids: Union[Unset, list[str]] = UNSET
+    property_order_duids: Union[Unset, list[str]] = UNSET
     property_width_map: Union[Unset, Any] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         order = self.order
@@ -60,7 +60,7 @@ class ViewCreate:
 
         accessible_by_team = self.accessible_by_team
 
-        accessible_by_user_duids: Union[Unset, List[str]] = UNSET
+        accessible_by_user_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.accessible_by_user_duids, Unset):
             accessible_by_user_duids = self.accessible_by_user_duids
 
@@ -78,25 +78,25 @@ class ViewCreate:
 
         color_hex = self.color_hex
 
-        favorited_by_user_duids: Union[Unset, List[str]] = UNSET
+        favorited_by_user_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.favorited_by_user_duids, Unset):
             favorited_by_user_duids = self.favorited_by_user_duids
 
-        always_shown_property_duids: Union[Unset, List[str]] = UNSET
+        always_shown_property_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.always_shown_property_duids, Unset):
             always_shown_property_duids = self.always_shown_property_duids
 
-        always_hidden_property_duids: Union[Unset, List[str]] = UNSET
+        always_hidden_property_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.always_hidden_property_duids, Unset):
             always_hidden_property_duids = self.always_hidden_property_duids
 
-        property_order_duids: Union[Unset, List[str]] = UNSET
+        property_order_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.property_order_duids, Unset):
             property_order_duids = self.property_order_duids
 
         property_width_map = self.property_width_map
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -135,7 +135,7 @@ class ViewCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -145,7 +145,7 @@ class ViewCreate:
 
         accessible_by_team = d.pop("accessibleByTeam", UNSET)
 
-        accessible_by_user_duids = cast(List[str], d.pop("accessibleByUserDuids", UNSET))
+        accessible_by_user_duids = cast(list[str], d.pop("accessibleByUserDuids", UNSET))
 
         public = d.pop("public", UNSET)
 
@@ -164,13 +164,13 @@ class ViewCreate:
 
         color_hex = d.pop("colorHex", UNSET)
 
-        favorited_by_user_duids = cast(List[str], d.pop("favoritedByUserDuids", UNSET))
+        favorited_by_user_duids = cast(list[str], d.pop("favoritedByUserDuids", UNSET))
 
-        always_shown_property_duids = cast(List[str], d.pop("alwaysShownPropertyDuids", UNSET))
+        always_shown_property_duids = cast(list[str], d.pop("alwaysShownPropertyDuids", UNSET))
 
-        always_hidden_property_duids = cast(List[str], d.pop("alwaysHiddenPropertyDuids", UNSET))
+        always_hidden_property_duids = cast(list[str], d.pop("alwaysHiddenPropertyDuids", UNSET))
 
-        property_order_duids = cast(List[str], d.pop("propertyOrderDuids", UNSET))
+        property_order_duids = cast(list[str], d.pop("propertyOrderDuids", UNSET))
 
         property_width_map = d.pop("propertyWidthMap", UNSET)
 
@@ -197,7 +197,7 @@ class ViewCreate:
         return view_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/view_create.py
+++ b/dart/generated/models/view_create.py
@@ -30,6 +30,7 @@ class ViewCreate:
         always_shown_property_duids (Union[Unset, List[str]]):
         always_hidden_property_duids (Union[Unset, List[str]]):
         property_order_duids (Union[Unset, List[str]]):
+        property_width_map (Union[Unset, Any]):
     """
 
     duid: str
@@ -47,6 +48,7 @@ class ViewCreate:
     always_shown_property_duids: Union[Unset, List[str]] = UNSET
     always_hidden_property_duids: Union[Unset, List[str]] = UNSET
     property_order_duids: Union[Unset, List[str]] = UNSET
+    property_width_map: Union[Unset, Any] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -92,6 +94,8 @@ class ViewCreate:
         if not isinstance(self.property_order_duids, Unset):
             property_order_duids = self.property_order_duids
 
+        property_width_map = self.property_width_map
+
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -125,6 +129,8 @@ class ViewCreate:
             field_dict["alwaysHiddenPropertyDuids"] = always_hidden_property_duids
         if property_order_duids is not UNSET:
             field_dict["propertyOrderDuids"] = property_order_duids
+        if property_width_map is not UNSET:
+            field_dict["propertyWidthMap"] = property_width_map
 
         return field_dict
 
@@ -166,6 +172,8 @@ class ViewCreate:
 
         property_order_duids = cast(List[str], d.pop("propertyOrderDuids", UNSET))
 
+        property_width_map = d.pop("propertyWidthMap", UNSET)
+
         view_create = cls(
             duid=duid,
             order=order,
@@ -182,6 +190,7 @@ class ViewCreate:
             always_shown_property_duids=always_shown_property_duids,
             always_hidden_property_duids=always_hidden_property_duids,
             property_order_duids=property_order_duids,
+            property_width_map=property_width_map,
         )
 
         view_create.additional_properties = d

--- a/dart/generated/models/view_update.py
+++ b/dart/generated/models/view_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -15,7 +15,7 @@ class ViewUpdate:
     Attributes:
         duid (str):
         accessible_by_team (Union[Unset, bool]):
-        accessible_by_user_duids (Union[Unset, List[str]]):
+        accessible_by_user_duids (Union[Unset, list[str]]):
         public (Union[Unset, bool]):
         order (Union[Unset, str]):
         title (Union[Unset, str]):
@@ -26,16 +26,16 @@ class ViewUpdate:
         icon_name_or_emoji (Union[Unset, str]):
         color_hex (Union[Unset, str]):
         layout_duid (Union[Unset, str]):
-        favorited_by_user_duids (Union[Unset, List[str]]):
-        always_shown_property_duids (Union[Unset, List[str]]):
-        always_hidden_property_duids (Union[Unset, List[str]]):
-        property_order_duids (Union[Unset, List[str]]):
+        favorited_by_user_duids (Union[Unset, list[str]]):
+        always_shown_property_duids (Union[Unset, list[str]]):
+        always_hidden_property_duids (Union[Unset, list[str]]):
+        property_order_duids (Union[Unset, list[str]]):
         property_width_map (Union[Unset, Any]):
     """
 
     duid: str
     accessible_by_team: Union[Unset, bool] = UNSET
-    accessible_by_user_duids: Union[Unset, List[str]] = UNSET
+    accessible_by_user_duids: Union[Unset, list[str]] = UNSET
     public: Union[Unset, bool] = UNSET
     order: Union[Unset, str] = UNSET
     title: Union[Unset, str] = UNSET
@@ -44,19 +44,19 @@ class ViewUpdate:
     icon_name_or_emoji: Union[Unset, str] = UNSET
     color_hex: Union[Unset, str] = UNSET
     layout_duid: Union[Unset, str] = UNSET
-    favorited_by_user_duids: Union[Unset, List[str]] = UNSET
-    always_shown_property_duids: Union[Unset, List[str]] = UNSET
-    always_hidden_property_duids: Union[Unset, List[str]] = UNSET
-    property_order_duids: Union[Unset, List[str]] = UNSET
+    favorited_by_user_duids: Union[Unset, list[str]] = UNSET
+    always_shown_property_duids: Union[Unset, list[str]] = UNSET
+    always_hidden_property_duids: Union[Unset, list[str]] = UNSET
+    property_order_duids: Union[Unset, list[str]] = UNSET
     property_width_map: Union[Unset, Any] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         accessible_by_team = self.accessible_by_team
 
-        accessible_by_user_duids: Union[Unset, List[str]] = UNSET
+        accessible_by_user_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.accessible_by_user_duids, Unset):
             accessible_by_user_duids = self.accessible_by_user_duids
 
@@ -78,25 +78,25 @@ class ViewUpdate:
 
         layout_duid = self.layout_duid
 
-        favorited_by_user_duids: Union[Unset, List[str]] = UNSET
+        favorited_by_user_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.favorited_by_user_duids, Unset):
             favorited_by_user_duids = self.favorited_by_user_duids
 
-        always_shown_property_duids: Union[Unset, List[str]] = UNSET
+        always_shown_property_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.always_shown_property_duids, Unset):
             always_shown_property_duids = self.always_shown_property_duids
 
-        always_hidden_property_duids: Union[Unset, List[str]] = UNSET
+        always_hidden_property_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.always_hidden_property_duids, Unset):
             always_hidden_property_duids = self.always_hidden_property_duids
 
-        property_order_duids: Union[Unset, List[str]] = UNSET
+        property_order_duids: Union[Unset, list[str]] = UNSET
         if not isinstance(self.property_order_duids, Unset):
             property_order_duids = self.property_order_duids
 
         property_width_map = self.property_width_map
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -137,13 +137,13 @@ class ViewUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
         accessible_by_team = d.pop("accessibleByTeam", UNSET)
 
-        accessible_by_user_duids = cast(List[str], d.pop("accessibleByUserDuids", UNSET))
+        accessible_by_user_duids = cast(list[str], d.pop("accessibleByUserDuids", UNSET))
 
         public = d.pop("public", UNSET)
 
@@ -166,13 +166,13 @@ class ViewUpdate:
 
         layout_duid = d.pop("layoutDuid", UNSET)
 
-        favorited_by_user_duids = cast(List[str], d.pop("favoritedByUserDuids", UNSET))
+        favorited_by_user_duids = cast(list[str], d.pop("favoritedByUserDuids", UNSET))
 
-        always_shown_property_duids = cast(List[str], d.pop("alwaysShownPropertyDuids", UNSET))
+        always_shown_property_duids = cast(list[str], d.pop("alwaysShownPropertyDuids", UNSET))
 
-        always_hidden_property_duids = cast(List[str], d.pop("alwaysHiddenPropertyDuids", UNSET))
+        always_hidden_property_duids = cast(list[str], d.pop("alwaysHiddenPropertyDuids", UNSET))
 
-        property_order_duids = cast(List[str], d.pop("propertyOrderDuids", UNSET))
+        property_order_duids = cast(list[str], d.pop("propertyOrderDuids", UNSET))
 
         property_width_map = d.pop("propertyWidthMap", UNSET)
 
@@ -199,7 +199,7 @@ class ViewUpdate:
         return view_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/view_update.py
+++ b/dart/generated/models/view_update.py
@@ -30,6 +30,7 @@ class ViewUpdate:
         always_shown_property_duids (Union[Unset, List[str]]):
         always_hidden_property_duids (Union[Unset, List[str]]):
         property_order_duids (Union[Unset, List[str]]):
+        property_width_map (Union[Unset, Any]):
     """
 
     duid: str
@@ -47,6 +48,7 @@ class ViewUpdate:
     always_shown_property_duids: Union[Unset, List[str]] = UNSET
     always_hidden_property_duids: Union[Unset, List[str]] = UNSET
     property_order_duids: Union[Unset, List[str]] = UNSET
+    property_width_map: Union[Unset, Any] = UNSET
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -92,6 +94,8 @@ class ViewUpdate:
         if not isinstance(self.property_order_duids, Unset):
             property_order_duids = self.property_order_duids
 
+        property_width_map = self.property_width_map
+
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -127,6 +131,8 @@ class ViewUpdate:
             field_dict["alwaysHiddenPropertyDuids"] = always_hidden_property_duids
         if property_order_duids is not UNSET:
             field_dict["propertyOrderDuids"] = property_order_duids
+        if property_width_map is not UNSET:
+            field_dict["propertyWidthMap"] = property_width_map
 
         return field_dict
 
@@ -168,6 +174,8 @@ class ViewUpdate:
 
         property_order_duids = cast(List[str], d.pop("propertyOrderDuids", UNSET))
 
+        property_width_map = d.pop("propertyWidthMap", UNSET)
+
         view_update = cls(
             duid=duid,
             accessible_by_team=accessible_by_team,
@@ -184,6 +192,7 @@ class ViewUpdate:
             always_shown_property_duids=always_shown_property_duids,
             always_hidden_property_duids=always_hidden_property_duids,
             property_order_duids=property_order_duids,
+            property_width_map=property_width_map,
         )
 
         view_update.additional_properties = d

--- a/dart/generated/models/webhook.py
+++ b/dart/generated/models/webhook.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union, cast
+from typing import Any, TypeVar, Union, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -22,9 +22,9 @@ class Webhook:
     order: str
     url: str
     updated_by_client_duid: Union[None, Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         order = self.order
@@ -37,7 +37,7 @@ class Webhook:
         else:
             updated_by_client_duid = self.updated_by_client_duid
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -52,7 +52,7 @@ class Webhook:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -80,7 +80,7 @@ class Webhook:
         return webhook
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/webhook_create.py
+++ b/dart/generated/models/webhook_create.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -20,16 +20,16 @@ class WebhookCreate:
     duid: str
     order: str
     url: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         order = self.order
 
         url = self.url
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -43,7 +43,7 @@ class WebhookCreate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -61,7 +61,7 @@ class WebhookCreate:
         return webhook_create
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/webhook_update.py
+++ b/dart/generated/models/webhook_update.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -20,16 +20,16 @@ class WebhookUpdate:
     duid: str
     order: Union[Unset, str] = UNSET
     url: Union[Unset, str] = UNSET
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         duid = self.duid
 
         order = self.order
 
         url = self.url
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -44,7 +44,7 @@ class WebhookUpdate:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         duid = d.pop("duid")
 
@@ -62,7 +62,7 @@ class WebhookUpdate:
         return webhook_update
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/models/zapier_integration.py
+++ b/dart/generated/models/zapier_integration.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -11,19 +11,19 @@ class ZapierIntegration:
     """
     Attributes:
         enabled (bool):
-        linked_user_duids (List[str]):
+        linked_user_duids (list[str]):
     """
 
     enabled: bool
-    linked_user_duids: List[str]
-    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+    linked_user_duids: list[str]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         enabled = self.enabled
 
         linked_user_duids = self.linked_user_duids
 
-        field_dict: Dict[str, Any] = {}
+        field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
@@ -35,11 +35,11 @@ class ZapierIntegration:
         return field_dict
 
     @classmethod
-    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
         d = src_dict.copy()
         enabled = d.pop("enabled")
 
-        linked_user_duids = cast(List[str], d.pop("linkedUserDuids"))
+        linked_user_duids = cast(list[str], d.pop("linkedUserDuids"))
 
         zapier_integration = cls(
             enabled=enabled,
@@ -50,7 +50,7 @@ class ZapierIntegration:
         return zapier_integration
 
     @property
-    def additional_keys(self) -> List[str]:
+    def additional_keys(self) -> list[str]:
         return list(self.additional_properties.keys())
 
     def __getitem__(self, key: str) -> Any:

--- a/dart/generated/types.py
+++ b/dart/generated/types.py
@@ -1,7 +1,8 @@
 """Contains some shared types for properties"""
 
+from collections.abc import MutableMapping
 from http import HTTPStatus
-from typing import BinaryIO, Generic, Literal, MutableMapping, Optional, Tuple, TypeVar
+from typing import BinaryIO, Generic, Literal, Optional, TypeVar
 
 from attrs import define
 
@@ -13,7 +14,7 @@ class Unset:
 
 UNSET: Unset = Unset()
 
-FileJsonType = Tuple[Optional[str], BinaryIO, Optional[str]]
+FileJsonType = tuple[Optional[str], BinaryIO, Optional[str]]
 
 
 @define
@@ -42,4 +43,4 @@ class Response(Generic[T]):
     parsed: Optional[T]
 
 
-__all__ = ["File", "Response", "FileJsonType", "Unset", "UNSET"]
+__all__ = ["UNSET", "File", "FileJsonType", "Response", "Unset"]

--- a/dart/order_manager.py
+++ b/dart/order_manager.py
@@ -1,3 +1,6 @@
+# Required for type hinting compatibility when using Python 3.9
+from __future__ import annotations
+
 # TODO dedupe with the other order manager
 from random import choices
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "dart-tools"
-version = "0.6.9"
+version = "0.6.10"
 description = "The Dart CLI and Python Library"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 license = {file = "LICENSE"}
 keywords = ["dart", "cli", "projectmanagement", "taskmanagement"]
@@ -20,7 +20,6 @@ classifiers=[
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
- Dropped support of Python 3.8 completely (see `pyproject.toml` diff) 'cause of missed support of [Union Operators To dict](https://peps.python.org/pep-0584/) used actively in the code
- Added using `from __future__ import annotations` to support Python 3.9 and higher and regenerated completely API
- Updated README on how to use Python library in AWS Lambda functions (the crucial thing is to build a deployment package for the runtime used for Lambda function, matching its Python version and arch)