### PR TITLE
Bump API to include agent and skill CRUD endpoints

### DIFF
--- a/dart/dart.py
+++ b/dart/dart.py
@@ -481,10 +481,7 @@ def _begin_task(dart: Dart, email: str, task: ConciseTask | Task) -> bool:
     return True
 
 
-def begin_task(
-    *,
-    dartboard_title: Union[Unset, str] = UNSET
-) -> bool:
+def begin_task(*, dartboard_title: Union[Unset, str] = UNSET) -> bool:
     dart = Dart()
     config = dart.get_config()
     user = config.user

--- a/dart/generated/api/__init__.py
+++ b/dart/generated/api/__init__.py
@@ -1,5 +1,6 @@
 """Contains methods for accessing the API"""
 
+from .agent import create_agent, delete_agent, get_agent, list_agents, update_agent
 from .attachment import add_task_attachment_from_url
 from .comment import add_task_comment, list_comments
 from .config import get_config
@@ -7,6 +8,6 @@ from .dartboard import get_dartboard
 from .doc import create_doc, delete_doc, get_doc, list_docs, update_doc
 from .folder import get_folder
 from .help_center_article import list_help_center_articles
-from .skill import retrieve_skill_by_title
+from .skill import create_skill, delete_skill, get_skill, list_skills, retrieve_skill_by_title, update_skill
 from .task import add_task_time_tracking, create_task, delete_task, get_task, list_tasks, move_task, update_task
 from .view import get_view

--- a/dart/generated/api/agent/__init__.py
+++ b/dart/generated/api/agent/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/dart/generated/api/agent/create_agent.py
+++ b/dart/generated/api/agent/create_agent.py
@@ -1,0 +1,172 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.wrapped_agent import WrappedAgent
+from ...models.wrapped_agent_create import WrappedAgentCreate
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: WrappedAgentCreate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/agents",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, WrappedAgent]]:
+    if response.status_code == 200:
+        response_200 = WrappedAgent.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, WrappedAgent]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: WrappedAgentCreate,
+) -> Response[Union[Any, WrappedAgent]]:
+    """Create a new custom agent
+
+     Create a new custom agent in the workspace with a name and optional description or instructions.
+
+    Args:
+        body (WrappedAgentCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, WrappedAgent]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    body: WrappedAgentCreate,
+) -> Optional[Union[Any, WrappedAgent]]:
+    """Create a new custom agent
+
+     Create a new custom agent in the workspace with a name and optional description or instructions.
+
+    Args:
+        body (WrappedAgentCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, WrappedAgent]
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: WrappedAgentCreate,
+) -> Response[Union[Any, WrappedAgent]]:
+    """Create a new custom agent
+
+     Create a new custom agent in the workspace with a name and optional description or instructions.
+
+    Args:
+        body (WrappedAgentCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, WrappedAgent]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    body: WrappedAgentCreate,
+) -> Optional[Union[Any, WrappedAgent]]:
+    """Create a new custom agent
+
+     Create a new custom agent in the workspace with a name and optional description or instructions.
+
+    Args:
+        body (WrappedAgentCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, WrappedAgent]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/dart/generated/api/agent/delete_agent.py
+++ b/dart/generated/api/agent/delete_agent.py
@@ -1,0 +1,165 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.wrapped_agent import WrappedAgent
+from ...types import Response
+
+
+def _get_kwargs(
+    id: str,
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/agents/{id}".format(
+            id=id,
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, WrappedAgent]]:
+    if response.status_code == 200:
+        response_200 = WrappedAgent.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, WrappedAgent]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Union[Any, WrappedAgent]]:
+    """Delete a custom agent
+
+     Delete a custom agent by its ID.
+
+    Args:
+        id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, WrappedAgent]]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Optional[Union[Any, WrappedAgent]]:
+    """Delete a custom agent
+
+     Delete a custom agent by its ID.
+
+    Args:
+        id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, WrappedAgent]
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Union[Any, WrappedAgent]]:
+    """Delete a custom agent
+
+     Delete a custom agent by its ID.
+
+    Args:
+        id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, WrappedAgent]]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Optional[Union[Any, WrappedAgent]]:
+    """Delete a custom agent
+
+     Delete a custom agent by its ID.
+
+    Args:
+        id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, WrappedAgent]
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/dart/generated/api/agent/get_agent.py
+++ b/dart/generated/api/agent/get_agent.py
@@ -1,0 +1,169 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.wrapped_agent import WrappedAgent
+from ...types import Response
+
+
+def _get_kwargs(
+    id: str,
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/agents/{id}".format(
+            id=id,
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, WrappedAgent]]:
+    if response.status_code == 200:
+        response_200 = WrappedAgent.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, WrappedAgent]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Union[Any, WrappedAgent]]:
+    """Retrieve an existing custom agent
+
+     Retrieve an existing custom agent by its ID, including its name and current description or
+    instructions.
+
+    Args:
+        id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, WrappedAgent]]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Optional[Union[Any, WrappedAgent]]:
+    """Retrieve an existing custom agent
+
+     Retrieve an existing custom agent by its ID, including its name and current description or
+    instructions.
+
+    Args:
+        id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, WrappedAgent]
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Union[Any, WrappedAgent]]:
+    """Retrieve an existing custom agent
+
+     Retrieve an existing custom agent by its ID, including its name and current description or
+    instructions.
+
+    Args:
+        id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, WrappedAgent]]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Optional[Union[Any, WrappedAgent]]:
+    """Retrieve an existing custom agent
+
+     Retrieve an existing custom agent by its ID, including its name and current description or
+    instructions.
+
+    Args:
+        id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, WrappedAgent]
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/dart/generated/api/agent/list_agents.py
+++ b/dart/generated/api/agent/list_agents.py
@@ -1,0 +1,186 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.paginated_agent_list import PaginatedAgentList
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    limit: Union[Unset, int] = UNSET,
+    offset: Union[Unset, int] = UNSET,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["limit"] = limit
+
+    params["offset"] = offset
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/agents/list",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[PaginatedAgentList]:
+    if response.status_code == 200:
+        response_200 = PaginatedAgentList.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[PaginatedAgentList]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    limit: Union[Unset, int] = UNSET,
+    offset: Union[Unset, int] = UNSET,
+) -> Response[PaginatedAgentList]:
+    """List all custom agents
+
+     List all custom agents in the workspace. Agents are AI assistants that can be assigned tasks and
+    have customizable instructions.
+
+    Args:
+        limit (Union[Unset, int]):
+        offset (Union[Unset, int]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[PaginatedAgentList]
+    """
+
+    kwargs = _get_kwargs(
+        limit=limit,
+        offset=offset,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    limit: Union[Unset, int] = UNSET,
+    offset: Union[Unset, int] = UNSET,
+) -> Optional[PaginatedAgentList]:
+    """List all custom agents
+
+     List all custom agents in the workspace. Agents are AI assistants that can be assigned tasks and
+    have customizable instructions.
+
+    Args:
+        limit (Union[Unset, int]):
+        offset (Union[Unset, int]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        PaginatedAgentList
+    """
+
+    return sync_detailed(
+        client=client,
+        limit=limit,
+        offset=offset,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    limit: Union[Unset, int] = UNSET,
+    offset: Union[Unset, int] = UNSET,
+) -> Response[PaginatedAgentList]:
+    """List all custom agents
+
+     List all custom agents in the workspace. Agents are AI assistants that can be assigned tasks and
+    have customizable instructions.
+
+    Args:
+        limit (Union[Unset, int]):
+        offset (Union[Unset, int]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[PaginatedAgentList]
+    """
+
+    kwargs = _get_kwargs(
+        limit=limit,
+        offset=offset,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    limit: Union[Unset, int] = UNSET,
+    offset: Union[Unset, int] = UNSET,
+) -> Optional[PaginatedAgentList]:
+    """List all custom agents
+
+     List all custom agents in the workspace. Agents are AI assistants that can be assigned tasks and
+    have customizable instructions.
+
+    Args:
+        limit (Union[Unset, int]):
+        offset (Union[Unset, int]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        PaginatedAgentList
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            limit=limit,
+            offset=offset,
+        )
+    ).parsed

--- a/dart/generated/api/agent/update_agent.py
+++ b/dart/generated/api/agent/update_agent.py
@@ -1,0 +1,195 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.wrapped_agent import WrappedAgent
+from ...models.wrapped_agent_update import WrappedAgentUpdate
+from ...types import Response
+
+
+def _get_kwargs(
+    id: str,
+    *,
+    body: WrappedAgentUpdate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/agents/{id}".format(
+            id=id,
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, WrappedAgent]]:
+    if response.status_code == 200:
+        response_200 = WrappedAgent.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, WrappedAgent]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+    body: WrappedAgentUpdate,
+) -> Response[Union[Any, WrappedAgent]]:
+    """Update a custom agent
+
+     Update a custom agent's name and/or description. Only the fields provided will be changed. The agent
+    is identified by its ID in the URL.
+
+    Args:
+        id (str):
+        body (WrappedAgentUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, WrappedAgent]]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+    body: WrappedAgentUpdate,
+) -> Optional[Union[Any, WrappedAgent]]:
+    """Update a custom agent
+
+     Update a custom agent's name and/or description. Only the fields provided will be changed. The agent
+    is identified by its ID in the URL.
+
+    Args:
+        id (str):
+        body (WrappedAgentUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, WrappedAgent]
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+    body: WrappedAgentUpdate,
+) -> Response[Union[Any, WrappedAgent]]:
+    """Update a custom agent
+
+     Update a custom agent's name and/or description. Only the fields provided will be changed. The agent
+    is identified by its ID in the URL.
+
+    Args:
+        id (str):
+        body (WrappedAgentUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, WrappedAgent]]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+    body: WrappedAgentUpdate,
+) -> Optional[Union[Any, WrappedAgent]]:
+    """Update a custom agent
+
+     Update a custom agent's name and/or description. Only the fields provided will be changed. The agent
+    is identified by its ID in the URL.
+
+    Args:
+        id (str):
+        body (WrappedAgentUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, WrappedAgent]
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/dart/generated/api/skill/create_skill.py
+++ b/dart/generated/api/skill/create_skill.py
@@ -1,0 +1,176 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.wrapped_skill import WrappedSkill
+from ...models.wrapped_skill_create import WrappedSkillCreate
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: WrappedSkillCreate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/skills",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, WrappedSkill]]:
+    if response.status_code == 200:
+        response_200 = WrappedSkill.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, WrappedSkill]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: WrappedSkillCreate,
+) -> Response[Union[Any, WrappedSkill]]:
+    """Create a new skill
+
+     Create a new custom skill with a title and instructions in markdown. The skill will be available to
+    all workspace members.
+
+    Args:
+        body (WrappedSkillCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, WrappedSkill]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    body: WrappedSkillCreate,
+) -> Optional[Union[Any, WrappedSkill]]:
+    """Create a new skill
+
+     Create a new custom skill with a title and instructions in markdown. The skill will be available to
+    all workspace members.
+
+    Args:
+        body (WrappedSkillCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, WrappedSkill]
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    body: WrappedSkillCreate,
+) -> Response[Union[Any, WrappedSkill]]:
+    """Create a new skill
+
+     Create a new custom skill with a title and instructions in markdown. The skill will be available to
+    all workspace members.
+
+    Args:
+        body (WrappedSkillCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, WrappedSkill]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    body: WrappedSkillCreate,
+) -> Optional[Union[Any, WrappedSkill]]:
+    """Create a new skill
+
+     Create a new custom skill with a title and instructions in markdown. The skill will be available to
+    all workspace members.
+
+    Args:
+        body (WrappedSkillCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, WrappedSkill]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/dart/generated/api/skill/delete_skill.py
+++ b/dart/generated/api/skill/delete_skill.py
@@ -1,0 +1,165 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.wrapped_skill import WrappedSkill
+from ...types import Response
+
+
+def _get_kwargs(
+    id: str,
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/skills/{id}".format(
+            id=id,
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, WrappedSkill]]:
+    if response.status_code == 200:
+        response_200 = WrappedSkill.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, WrappedSkill]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Union[Any, WrappedSkill]]:
+    """Delete an existing skill
+
+     Delete a skill by its ID. The skill will be permanently removed from the workspace.
+
+    Args:
+        id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, WrappedSkill]]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Optional[Union[Any, WrappedSkill]]:
+    """Delete an existing skill
+
+     Delete a skill by its ID. The skill will be permanently removed from the workspace.
+
+    Args:
+        id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, WrappedSkill]
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Union[Any, WrappedSkill]]:
+    """Delete an existing skill
+
+     Delete a skill by its ID. The skill will be permanently removed from the workspace.
+
+    Args:
+        id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, WrappedSkill]]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Optional[Union[Any, WrappedSkill]]:
+    """Delete an existing skill
+
+     Delete a skill by its ID. The skill will be permanently removed from the workspace.
+
+    Args:
+        id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, WrappedSkill]
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/dart/generated/api/skill/get_skill.py
+++ b/dart/generated/api/skill/get_skill.py
@@ -1,0 +1,165 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.wrapped_skill import WrappedSkill
+from ...types import Response
+
+
+def _get_kwargs(
+    id: str,
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/skills/{id}".format(
+            id=id,
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, WrappedSkill]]:
+    if response.status_code == 200:
+        response_200 = WrappedSkill.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, WrappedSkill]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Union[Any, WrappedSkill]]:
+    """Retrieve an existing skill
+
+     Retrieve an existing skill by its ID. Returns the skill's title and instructions.
+
+    Args:
+        id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, WrappedSkill]]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Optional[Union[Any, WrappedSkill]]:
+    """Retrieve an existing skill
+
+     Retrieve an existing skill by its ID. Returns the skill's title and instructions.
+
+    Args:
+        id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, WrappedSkill]
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Response[Union[Any, WrappedSkill]]:
+    """Retrieve an existing skill
+
+     Retrieve an existing skill by its ID. Returns the skill's title and instructions.
+
+    Args:
+        id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, WrappedSkill]]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+) -> Optional[Union[Any, WrappedSkill]]:
+    """Retrieve an existing skill
+
+     Retrieve an existing skill by its ID. Returns the skill's title and instructions.
+
+    Args:
+        id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, WrappedSkill]
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/dart/generated/api/skill/list_skills.py
+++ b/dart/generated/api/skill/list_skills.py
@@ -1,0 +1,186 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.paginated_skill_list import PaginatedSkillList
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    limit: Union[Unset, int] = UNSET,
+    offset: Union[Unset, int] = UNSET,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["limit"] = limit
+
+    params["offset"] = offset
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/skills/list",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[PaginatedSkillList]:
+    if response.status_code == 200:
+        response_200 = PaginatedSkillList.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[PaginatedSkillList]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    limit: Union[Unset, int] = UNSET,
+    offset: Union[Unset, int] = UNSET,
+) -> Response[PaginatedSkillList]:
+    """List all skills
+
+     List all skills in the workspace. Skills are user-defined instructions or templates for performing
+    specific task types.
+
+    Args:
+        limit (Union[Unset, int]):
+        offset (Union[Unset, int]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[PaginatedSkillList]
+    """
+
+    kwargs = _get_kwargs(
+        limit=limit,
+        offset=offset,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    limit: Union[Unset, int] = UNSET,
+    offset: Union[Unset, int] = UNSET,
+) -> Optional[PaginatedSkillList]:
+    """List all skills
+
+     List all skills in the workspace. Skills are user-defined instructions or templates for performing
+    specific task types.
+
+    Args:
+        limit (Union[Unset, int]):
+        offset (Union[Unset, int]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        PaginatedSkillList
+    """
+
+    return sync_detailed(
+        client=client,
+        limit=limit,
+        offset=offset,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    limit: Union[Unset, int] = UNSET,
+    offset: Union[Unset, int] = UNSET,
+) -> Response[PaginatedSkillList]:
+    """List all skills
+
+     List all skills in the workspace. Skills are user-defined instructions or templates for performing
+    specific task types.
+
+    Args:
+        limit (Union[Unset, int]):
+        offset (Union[Unset, int]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[PaginatedSkillList]
+    """
+
+    kwargs = _get_kwargs(
+        limit=limit,
+        offset=offset,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    limit: Union[Unset, int] = UNSET,
+    offset: Union[Unset, int] = UNSET,
+) -> Optional[PaginatedSkillList]:
+    """List all skills
+
+     List all skills in the workspace. Skills are user-defined instructions or templates for performing
+    specific task types.
+
+    Args:
+        limit (Union[Unset, int]):
+        offset (Union[Unset, int]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        PaginatedSkillList
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            limit=limit,
+            offset=offset,
+        )
+    ).parsed

--- a/dart/generated/api/skill/update_skill.py
+++ b/dart/generated/api/skill/update_skill.py
@@ -1,0 +1,195 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.wrapped_skill import WrappedSkill
+from ...models.wrapped_skill_update import WrappedSkillUpdate
+from ...types import Response
+
+
+def _get_kwargs(
+    id: str,
+    *,
+    body: WrappedSkillUpdate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": "/skills/{id}".format(
+            id=id,
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, WrappedSkill]]:
+    if response.status_code == 200:
+        response_200 = WrappedSkill.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 400:
+        response_400 = cast(Any, None)
+        return response_400
+
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, WrappedSkill]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+    body: WrappedSkillUpdate,
+) -> Response[Union[Any, WrappedSkill]]:
+    """Update an existing skill
+
+     Update an existing skill's title and/or instructions. Only the fields provided will be updated. The
+    skill is identified by its ID in the URL.
+
+    Args:
+        id (str):
+        body (WrappedSkillUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, WrappedSkill]]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+    body: WrappedSkillUpdate,
+) -> Optional[Union[Any, WrappedSkill]]:
+    """Update an existing skill
+
+     Update an existing skill's title and/or instructions. Only the fields provided will be updated. The
+    skill is identified by its ID in the URL.
+
+    Args:
+        id (str):
+        body (WrappedSkillUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, WrappedSkill]
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+    body: WrappedSkillUpdate,
+) -> Response[Union[Any, WrappedSkill]]:
+    """Update an existing skill
+
+     Update an existing skill's title and/or instructions. Only the fields provided will be updated. The
+    skill is identified by its ID in the URL.
+
+    Args:
+        id (str):
+        body (WrappedSkillUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, WrappedSkill]]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: str,
+    *,
+    client: AuthenticatedClient,
+    body: WrappedSkillUpdate,
+) -> Optional[Union[Any, WrappedSkill]]:
+    """Update an existing skill
+
+     Update an existing skill's title and/or instructions. Only the fields provided will be updated. The
+    skill is identified by its ID in the URL.
+
+    Args:
+        id (str):
+        body (WrappedSkillUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, WrappedSkill]
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/dart/generated/models/__init__.py
+++ b/dart/generated/models/__init__.py
@@ -1,5 +1,8 @@
 """Contains all the data models used in inputs/outputs"""
 
+from .agent import Agent
+from .agent_create import AgentCreate
+from .agent_update import AgentUpdate
 from .attachment import Attachment
 from .attachment_create_from_url import AttachmentCreateFromUrl
 from .comment import Comment
@@ -16,6 +19,11 @@ from .help_center_article import HelpCenterArticle
 from .list_comments_o_item import ListCommentsOItem
 from .list_docs_o_item import ListDocsOItem
 from .list_tasks_o_item import ListTasksOItem
+from .paginated_agent_list import PaginatedAgentList
+from .paginated_agent_list_meta_type_0 import PaginatedAgentListMetaType0
+from .paginated_agent_list_meta_type_0_applied_default_filters import (
+    PaginatedAgentListMetaType0AppliedDefaultFilters,
+)
 from .paginated_comment_list import PaginatedCommentList
 from .paginated_comment_list_meta_type_0 import PaginatedCommentListMetaType0
 from .paginated_comment_list_meta_type_0_applied_default_filters import (
@@ -31,8 +39,15 @@ from .paginated_concise_task_list_meta_type_0 import PaginatedConciseTaskListMet
 from .paginated_concise_task_list_meta_type_0_applied_default_filters import (
     PaginatedConciseTaskListMetaType0AppliedDefaultFilters,
 )
+from .paginated_skill_list import PaginatedSkillList
+from .paginated_skill_list_meta_type_0 import PaginatedSkillListMetaType0
+from .paginated_skill_list_meta_type_0_applied_default_filters import (
+    PaginatedSkillListMetaType0AppliedDefaultFilters,
+)
 from .priority import Priority
 from .skill import Skill
+from .skill_create import SkillCreate
+from .skill_update import SkillUpdate
 from .task import Task
 from .task_create import TaskCreate
 from .task_create_custom_properties_type_0 import TaskCreateCustomPropertiesType0
@@ -76,6 +91,9 @@ from .user_space_configuration_custom_property_user_type_def import (
     UserSpaceConfigurationCustomPropertyUserTypeDef,
 )
 from .view import View
+from .wrapped_agent import WrappedAgent
+from .wrapped_agent_create import WrappedAgentCreate
+from .wrapped_agent_update import WrappedAgentUpdate
 from .wrapped_comment import WrappedComment
 from .wrapped_comment_create import WrappedCommentCreate
 from .wrapped_dartboard import WrappedDartboard
@@ -85,12 +103,17 @@ from .wrapped_doc_update import WrappedDocUpdate
 from .wrapped_folder import WrappedFolder
 from .wrapped_help_center_articles import WrappedHelpCenterArticles
 from .wrapped_skill import WrappedSkill
+from .wrapped_skill_create import WrappedSkillCreate
+from .wrapped_skill_update import WrappedSkillUpdate
 from .wrapped_task import WrappedTask
 from .wrapped_task_create import WrappedTaskCreate
 from .wrapped_task_update import WrappedTaskUpdate
 from .wrapped_view import WrappedView
 
 __all__ = (
+    "Agent",
+    "AgentCreate",
+    "AgentUpdate",
     "Attachment",
     "AttachmentCreateFromUrl",
     "Comment",
@@ -107,6 +130,9 @@ __all__ = (
     "ListCommentsOItem",
     "ListDocsOItem",
     "ListTasksOItem",
+    "PaginatedAgentList",
+    "PaginatedAgentListMetaType0",
+    "PaginatedAgentListMetaType0AppliedDefaultFilters",
     "PaginatedCommentList",
     "PaginatedCommentListMetaType0",
     "PaginatedCommentListMetaType0AppliedDefaultFilters",
@@ -116,8 +142,13 @@ __all__ = (
     "PaginatedConciseTaskList",
     "PaginatedConciseTaskListMetaType0",
     "PaginatedConciseTaskListMetaType0AppliedDefaultFilters",
+    "PaginatedSkillList",
+    "PaginatedSkillListMetaType0",
+    "PaginatedSkillListMetaType0AppliedDefaultFilters",
     "Priority",
     "Skill",
+    "SkillCreate",
+    "SkillUpdate",
     "Task",
     "TaskCreate",
     "TaskCreateCustomPropertiesType0",
@@ -141,6 +172,9 @@ __all__ = (
     "UserSpaceConfigurationCustomPropertyTimeTrackingTypeDef",
     "UserSpaceConfigurationCustomPropertyUserTypeDef",
     "View",
+    "WrappedAgent",
+    "WrappedAgentCreate",
+    "WrappedAgentUpdate",
     "WrappedComment",
     "WrappedCommentCreate",
     "WrappedDartboard",
@@ -150,6 +184,8 @@ __all__ = (
     "WrappedFolder",
     "WrappedHelpCenterArticles",
     "WrappedSkill",
+    "WrappedSkillCreate",
+    "WrappedSkillUpdate",
     "WrappedTask",
     "WrappedTaskCreate",
     "WrappedTaskUpdate",

--- a/dart/generated/models/agent.py
+++ b/dart/generated/models/agent.py
@@ -1,0 +1,83 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="Agent")
+
+
+@_attrs_define
+class Agent:
+    """
+    Attributes:
+        id (str): The universal, unique ID of the agent.
+        name (str): The display name of the agent.
+        enabled (bool): Whether the agent is currently enabled.
+        prompt_markdown (str): The agent's instructions in markdown format.
+    """
+
+    id: str
+    name: str
+    enabled: bool
+    prompt_markdown: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        name = self.name
+
+        enabled = self.enabled
+
+        prompt_markdown = self.prompt_markdown
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "name": name,
+                "enabled": enabled,
+                "promptMarkdown": prompt_markdown,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        name = d.pop("name")
+
+        enabled = d.pop("enabled")
+
+        prompt_markdown = d.pop("promptMarkdown")
+
+        agent = cls(
+            id=id,
+            name=name,
+            enabled=enabled,
+            prompt_markdown=prompt_markdown,
+        )
+
+        agent.additional_properties = d
+        return agent
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/dart/generated/models/agent_create.py
+++ b/dart/generated/models/agent_create.py
@@ -1,0 +1,74 @@
+from collections.abc import Mapping
+from typing import (
+    Any,
+    TypeVar,
+    Union,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="AgentCreate")
+
+
+@_attrs_define
+class AgentCreate:
+    """
+    Attributes:
+        name (str): The display name of the new agent.
+        prompt_markdown (Union[Unset, str]): Initial instructions for the agent in markdown format.
+    """
+
+    name: str
+    prompt_markdown: Union[Unset, str] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        name = self.name
+
+        prompt_markdown = self.prompt_markdown
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "name": name,
+            }
+        )
+        if prompt_markdown is not UNSET:
+            field_dict["promptMarkdown"] = prompt_markdown
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        prompt_markdown = d.pop("promptMarkdown", UNSET)
+
+        agent_create = cls(
+            name=name,
+            prompt_markdown=prompt_markdown,
+        )
+
+        agent_create.additional_properties = d
+        return agent_create
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/dart/generated/models/agent_update.py
+++ b/dart/generated/models/agent_update.py
@@ -1,0 +1,83 @@
+from collections.abc import Mapping
+from typing import (
+    Any,
+    TypeVar,
+    Union,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="AgentUpdate")
+
+
+@_attrs_define
+class AgentUpdate:
+    """
+    Attributes:
+        id (str): The universal, unique ID of the agent.
+        name (Union[Unset, str]): The new display name for the agent.
+        prompt_markdown (Union[Unset, str]): The full replacement instructions for the agent in markdown format.
+    """
+
+    id: str
+    name: Union[Unset, str] = UNSET
+    prompt_markdown: Union[Unset, str] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        name = self.name
+
+        prompt_markdown = self.prompt_markdown
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+            }
+        )
+        if name is not UNSET:
+            field_dict["name"] = name
+        if prompt_markdown is not UNSET:
+            field_dict["promptMarkdown"] = prompt_markdown
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        name = d.pop("name", UNSET)
+
+        prompt_markdown = d.pop("promptMarkdown", UNSET)
+
+        agent_update = cls(
+            id=id,
+            name=name,
+            prompt_markdown=prompt_markdown,
+        )
+
+        agent_update.additional_properties = d
+        return agent_update
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/dart/generated/models/paginated_agent_list.py
+++ b/dart/generated/models/paginated_agent_list.py
@@ -1,0 +1,169 @@
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    TypeVar,
+    Union,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.agent import Agent
+    from ..models.paginated_agent_list_meta_type_0 import PaginatedAgentListMetaType0
+
+
+T = TypeVar("T", bound="PaginatedAgentList")
+
+
+@_attrs_define
+class PaginatedAgentList:
+    """
+    Attributes:
+        count (int):  Example: 123.
+        results (list['Agent']):
+        next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
+        previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
+        meta (Union['PaginatedAgentListMetaType0', None, Unset]):
+    """
+
+    count: int
+    results: list["Agent"]
+    next_: Union[None, Unset, str] = UNSET
+    previous: Union[None, Unset, str] = UNSET
+    meta: Union["PaginatedAgentListMetaType0", None, Unset] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.paginated_agent_list_meta_type_0 import (
+            PaginatedAgentListMetaType0,
+        )
+
+        count = self.count
+
+        results = []
+        for results_item_data in self.results:
+            results_item = results_item_data.to_dict()
+            results.append(results_item)
+
+        next_: Union[None, Unset, str]
+        if isinstance(self.next_, Unset):
+            next_ = UNSET
+        else:
+            next_ = self.next_
+
+        previous: Union[None, Unset, str]
+        if isinstance(self.previous, Unset):
+            previous = UNSET
+        else:
+            previous = self.previous
+
+        meta: Union[None, Unset, dict[str, Any]]
+        if isinstance(self.meta, Unset):
+            meta = UNSET
+        elif isinstance(self.meta, PaginatedAgentListMetaType0):
+            meta = self.meta.to_dict()
+        else:
+            meta = self.meta
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "count": count,
+                "results": results,
+            }
+        )
+        if next_ is not UNSET:
+            field_dict["next"] = next_
+        if previous is not UNSET:
+            field_dict["previous"] = previous
+        if meta is not UNSET:
+            field_dict["meta"] = meta
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.agent import Agent
+        from ..models.paginated_agent_list_meta_type_0 import (
+            PaginatedAgentListMetaType0,
+        )
+
+        d = dict(src_dict)
+        count = d.pop("count")
+
+        results = []
+        _results = d.pop("results")
+        for results_item_data in _results:
+            results_item = Agent.from_dict(results_item_data)
+
+            results.append(results_item)
+
+        def _parse_next_(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        next_ = _parse_next_(d.pop("next", UNSET))
+
+        def _parse_previous(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        previous = _parse_previous(d.pop("previous", UNSET))
+
+        def _parse_meta(
+            data: object,
+        ) -> Union["PaginatedAgentListMetaType0", None, Unset]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                meta_type_0 = PaginatedAgentListMetaType0.from_dict(data)
+
+                return meta_type_0
+            except:  # noqa: E722
+                pass
+            return cast(Union["PaginatedAgentListMetaType0", None, Unset], data)
+
+        meta = _parse_meta(d.pop("meta", UNSET))
+
+        paginated_agent_list = cls(
+            count=count,
+            results=results,
+            next_=next_,
+            previous=previous,
+            meta=meta,
+        )
+
+        paginated_agent_list.additional_properties = d
+        return paginated_agent_list
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/dart/generated/models/paginated_agent_list_meta_type_0.py
+++ b/dart/generated/models/paginated_agent_list_meta_type_0.py
@@ -1,0 +1,115 @@
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    TypeVar,
+    Union,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.paginated_agent_list_meta_type_0_applied_default_filters import (
+        PaginatedAgentListMetaType0AppliedDefaultFilters,
+    )
+
+
+T = TypeVar("T", bound="PaginatedAgentListMetaType0")
+
+
+@_attrs_define
+class PaginatedAgentListMetaType0:
+    """
+    Attributes:
+        defaults_applied (Union[Unset, bool]): Whether default filters or ordering were applied to the response.
+        applied_default_filters (Union[Unset, PaginatedAgentListMetaType0AppliedDefaultFilters]): The default filters
+            that were applied automatically, if any.
+        applied_default_sorts (Union[Unset, list[str]]): The default ordering fields that were applied automatically, if
+            any.
+        instructions (Union[Unset, str]): Guidance on how to disable or override default filters and ordering.
+    """
+
+    defaults_applied: Union[Unset, bool] = UNSET
+    applied_default_filters: Union[Unset, "PaginatedAgentListMetaType0AppliedDefaultFilters"] = UNSET
+    applied_default_sorts: Union[Unset, list[str]] = UNSET
+    instructions: Union[Unset, str] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        defaults_applied = self.defaults_applied
+
+        applied_default_filters: Union[Unset, dict[str, Any]] = UNSET
+        if not isinstance(self.applied_default_filters, Unset):
+            applied_default_filters = self.applied_default_filters.to_dict()
+
+        applied_default_sorts: Union[Unset, list[str]] = UNSET
+        if not isinstance(self.applied_default_sorts, Unset):
+            applied_default_sorts = self.applied_default_sorts
+
+        instructions = self.instructions
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if defaults_applied is not UNSET:
+            field_dict["defaultsApplied"] = defaults_applied
+        if applied_default_filters is not UNSET:
+            field_dict["appliedDefaultFilters"] = applied_default_filters
+        if applied_default_sorts is not UNSET:
+            field_dict["appliedDefaultSorts"] = applied_default_sorts
+        if instructions is not UNSET:
+            field_dict["instructions"] = instructions
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.paginated_agent_list_meta_type_0_applied_default_filters import (
+            PaginatedAgentListMetaType0AppliedDefaultFilters,
+        )
+
+        d = dict(src_dict)
+        defaults_applied = d.pop("defaultsApplied", UNSET)
+
+        _applied_default_filters = d.pop("appliedDefaultFilters", UNSET)
+        applied_default_filters: Union[Unset, PaginatedAgentListMetaType0AppliedDefaultFilters]
+        if isinstance(_applied_default_filters, Unset):
+            applied_default_filters = UNSET
+        else:
+            applied_default_filters = PaginatedAgentListMetaType0AppliedDefaultFilters.from_dict(
+                _applied_default_filters
+            )
+
+        applied_default_sorts = cast(list[str], d.pop("appliedDefaultSorts", UNSET))
+
+        instructions = d.pop("instructions", UNSET)
+
+        paginated_agent_list_meta_type_0 = cls(
+            defaults_applied=defaults_applied,
+            applied_default_filters=applied_default_filters,
+            applied_default_sorts=applied_default_sorts,
+            instructions=instructions,
+        )
+
+        paginated_agent_list_meta_type_0.additional_properties = d
+        return paginated_agent_list_meta_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/dart/generated/models/paginated_agent_list_meta_type_0_applied_default_filters.py
+++ b/dart/generated/models/paginated_agent_list_meta_type_0_applied_default_filters.py
@@ -1,0 +1,44 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="PaginatedAgentListMetaType0AppliedDefaultFilters")
+
+
+@_attrs_define
+class PaginatedAgentListMetaType0AppliedDefaultFilters:
+    """The default filters that were applied automatically, if any."""
+
+    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        paginated_agent_list_meta_type_0_applied_default_filters = cls()
+
+        paginated_agent_list_meta_type_0_applied_default_filters.additional_properties = d
+        return paginated_agent_list_meta_type_0_applied_default_filters
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/dart/generated/models/paginated_skill_list.py
+++ b/dart/generated/models/paginated_skill_list.py
@@ -1,0 +1,169 @@
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    TypeVar,
+    Union,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.paginated_skill_list_meta_type_0 import PaginatedSkillListMetaType0
+    from ..models.skill import Skill
+
+
+T = TypeVar("T", bound="PaginatedSkillList")
+
+
+@_attrs_define
+class PaginatedSkillList:
+    """
+    Attributes:
+        count (int):  Example: 123.
+        results (list['Skill']):
+        next_ (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=400&limit=100.
+        previous (Union[None, Unset, str]):  Example: http://api.example.org/accounts/?offset=200&limit=100.
+        meta (Union['PaginatedSkillListMetaType0', None, Unset]):
+    """
+
+    count: int
+    results: list["Skill"]
+    next_: Union[None, Unset, str] = UNSET
+    previous: Union[None, Unset, str] = UNSET
+    meta: Union["PaginatedSkillListMetaType0", None, Unset] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.paginated_skill_list_meta_type_0 import (
+            PaginatedSkillListMetaType0,
+        )
+
+        count = self.count
+
+        results = []
+        for results_item_data in self.results:
+            results_item = results_item_data.to_dict()
+            results.append(results_item)
+
+        next_: Union[None, Unset, str]
+        if isinstance(self.next_, Unset):
+            next_ = UNSET
+        else:
+            next_ = self.next_
+
+        previous: Union[None, Unset, str]
+        if isinstance(self.previous, Unset):
+            previous = UNSET
+        else:
+            previous = self.previous
+
+        meta: Union[None, Unset, dict[str, Any]]
+        if isinstance(self.meta, Unset):
+            meta = UNSET
+        elif isinstance(self.meta, PaginatedSkillListMetaType0):
+            meta = self.meta.to_dict()
+        else:
+            meta = self.meta
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "count": count,
+                "results": results,
+            }
+        )
+        if next_ is not UNSET:
+            field_dict["next"] = next_
+        if previous is not UNSET:
+            field_dict["previous"] = previous
+        if meta is not UNSET:
+            field_dict["meta"] = meta
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.paginated_skill_list_meta_type_0 import (
+            PaginatedSkillListMetaType0,
+        )
+        from ..models.skill import Skill
+
+        d = dict(src_dict)
+        count = d.pop("count")
+
+        results = []
+        _results = d.pop("results")
+        for results_item_data in _results:
+            results_item = Skill.from_dict(results_item_data)
+
+            results.append(results_item)
+
+        def _parse_next_(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        next_ = _parse_next_(d.pop("next", UNSET))
+
+        def _parse_previous(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        previous = _parse_previous(d.pop("previous", UNSET))
+
+        def _parse_meta(
+            data: object,
+        ) -> Union["PaginatedSkillListMetaType0", None, Unset]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                meta_type_0 = PaginatedSkillListMetaType0.from_dict(data)
+
+                return meta_type_0
+            except:  # noqa: E722
+                pass
+            return cast(Union["PaginatedSkillListMetaType0", None, Unset], data)
+
+        meta = _parse_meta(d.pop("meta", UNSET))
+
+        paginated_skill_list = cls(
+            count=count,
+            results=results,
+            next_=next_,
+            previous=previous,
+            meta=meta,
+        )
+
+        paginated_skill_list.additional_properties = d
+        return paginated_skill_list
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/dart/generated/models/paginated_skill_list_meta_type_0.py
+++ b/dart/generated/models/paginated_skill_list_meta_type_0.py
@@ -1,0 +1,115 @@
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    TypeVar,
+    Union,
+    cast,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.paginated_skill_list_meta_type_0_applied_default_filters import (
+        PaginatedSkillListMetaType0AppliedDefaultFilters,
+    )
+
+
+T = TypeVar("T", bound="PaginatedSkillListMetaType0")
+
+
+@_attrs_define
+class PaginatedSkillListMetaType0:
+    """
+    Attributes:
+        defaults_applied (Union[Unset, bool]): Whether default filters or ordering were applied to the response.
+        applied_default_filters (Union[Unset, PaginatedSkillListMetaType0AppliedDefaultFilters]): The default filters
+            that were applied automatically, if any.
+        applied_default_sorts (Union[Unset, list[str]]): The default ordering fields that were applied automatically, if
+            any.
+        instructions (Union[Unset, str]): Guidance on how to disable or override default filters and ordering.
+    """
+
+    defaults_applied: Union[Unset, bool] = UNSET
+    applied_default_filters: Union[Unset, "PaginatedSkillListMetaType0AppliedDefaultFilters"] = UNSET
+    applied_default_sorts: Union[Unset, list[str]] = UNSET
+    instructions: Union[Unset, str] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        defaults_applied = self.defaults_applied
+
+        applied_default_filters: Union[Unset, dict[str, Any]] = UNSET
+        if not isinstance(self.applied_default_filters, Unset):
+            applied_default_filters = self.applied_default_filters.to_dict()
+
+        applied_default_sorts: Union[Unset, list[str]] = UNSET
+        if not isinstance(self.applied_default_sorts, Unset):
+            applied_default_sorts = self.applied_default_sorts
+
+        instructions = self.instructions
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if defaults_applied is not UNSET:
+            field_dict["defaultsApplied"] = defaults_applied
+        if applied_default_filters is not UNSET:
+            field_dict["appliedDefaultFilters"] = applied_default_filters
+        if applied_default_sorts is not UNSET:
+            field_dict["appliedDefaultSorts"] = applied_default_sorts
+        if instructions is not UNSET:
+            field_dict["instructions"] = instructions
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.paginated_skill_list_meta_type_0_applied_default_filters import (
+            PaginatedSkillListMetaType0AppliedDefaultFilters,
+        )
+
+        d = dict(src_dict)
+        defaults_applied = d.pop("defaultsApplied", UNSET)
+
+        _applied_default_filters = d.pop("appliedDefaultFilters", UNSET)
+        applied_default_filters: Union[Unset, PaginatedSkillListMetaType0AppliedDefaultFilters]
+        if isinstance(_applied_default_filters, Unset):
+            applied_default_filters = UNSET
+        else:
+            applied_default_filters = PaginatedSkillListMetaType0AppliedDefaultFilters.from_dict(
+                _applied_default_filters
+            )
+
+        applied_default_sorts = cast(list[str], d.pop("appliedDefaultSorts", UNSET))
+
+        instructions = d.pop("instructions", UNSET)
+
+        paginated_skill_list_meta_type_0 = cls(
+            defaults_applied=defaults_applied,
+            applied_default_filters=applied_default_filters,
+            applied_default_sorts=applied_default_sorts,
+            instructions=instructions,
+        )
+
+        paginated_skill_list_meta_type_0.additional_properties = d
+        return paginated_skill_list_meta_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/dart/generated/models/paginated_skill_list_meta_type_0_applied_default_filters.py
+++ b/dart/generated/models/paginated_skill_list_meta_type_0_applied_default_filters.py
@@ -1,0 +1,44 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="PaginatedSkillListMetaType0AppliedDefaultFilters")
+
+
+@_attrs_define
+class PaginatedSkillListMetaType0AppliedDefaultFilters:
+    """The default filters that were applied automatically, if any."""
+
+    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        paginated_skill_list_meta_type_0_applied_default_filters = cls()
+
+        paginated_skill_list_meta_type_0_applied_default_filters.additional_properties = d
+        return paginated_skill_list_meta_type_0_applied_default_filters
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/dart/generated/models/skill_create.py
+++ b/dart/generated/models/skill_create.py
@@ -1,0 +1,67 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="SkillCreate")
+
+
+@_attrs_define
+class SkillCreate:
+    """
+    Attributes:
+        title (str): The title of the skill, describing the task type.
+        prompt_markdown (str): User-defined instructions for performing this skill in markdown format.
+    """
+
+    title: str
+    prompt_markdown: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        title = self.title
+
+        prompt_markdown = self.prompt_markdown
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "title": title,
+                "promptMarkdown": prompt_markdown,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        title = d.pop("title")
+
+        prompt_markdown = d.pop("promptMarkdown")
+
+        skill_create = cls(
+            title=title,
+            prompt_markdown=prompt_markdown,
+        )
+
+        skill_create.additional_properties = d
+        return skill_create
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/dart/generated/models/skill_update.py
+++ b/dart/generated/models/skill_update.py
@@ -1,0 +1,83 @@
+from collections.abc import Mapping
+from typing import (
+    Any,
+    TypeVar,
+    Union,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="SkillUpdate")
+
+
+@_attrs_define
+class SkillUpdate:
+    """
+    Attributes:
+        id (str): The universal, unique ID of the skill.
+        title (Union[Unset, str]): The title of the skill, describing the task type.
+        prompt_markdown (Union[Unset, str]): User-defined instructions for performing this skill in markdown format.
+    """
+
+    id: str
+    title: Union[Unset, str] = UNSET
+    prompt_markdown: Union[Unset, str] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
+        title = self.title
+
+        prompt_markdown = self.prompt_markdown
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+            }
+        )
+        if title is not UNSET:
+            field_dict["title"] = title
+        if prompt_markdown is not UNSET:
+            field_dict["promptMarkdown"] = prompt_markdown
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = d.pop("id")
+
+        title = d.pop("title", UNSET)
+
+        prompt_markdown = d.pop("promptMarkdown", UNSET)
+
+        skill_update = cls(
+            id=id,
+            title=title,
+            prompt_markdown=prompt_markdown,
+        )
+
+        skill_update.additional_properties = d
+        return skill_update
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/dart/generated/models/wrapped_agent.py
+++ b/dart/generated/models/wrapped_agent.py
@@ -1,0 +1,69 @@
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    TypeVar,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.agent import Agent
+
+
+T = TypeVar("T", bound="WrappedAgent")
+
+
+@_attrs_define
+class WrappedAgent:
+    """
+    Attributes:
+        item (Agent):
+    """
+
+    item: "Agent"
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        item = self.item.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "item": item,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.agent import Agent
+
+        d = dict(src_dict)
+        item = Agent.from_dict(d.pop("item"))
+
+        wrapped_agent = cls(
+            item=item,
+        )
+
+        wrapped_agent.additional_properties = d
+        return wrapped_agent
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/dart/generated/models/wrapped_agent_create.py
+++ b/dart/generated/models/wrapped_agent_create.py
@@ -1,0 +1,69 @@
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    TypeVar,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.agent_create import AgentCreate
+
+
+T = TypeVar("T", bound="WrappedAgentCreate")
+
+
+@_attrs_define
+class WrappedAgentCreate:
+    """
+    Attributes:
+        item (AgentCreate):
+    """
+
+    item: "AgentCreate"
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        item = self.item.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "item": item,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.agent_create import AgentCreate
+
+        d = dict(src_dict)
+        item = AgentCreate.from_dict(d.pop("item"))
+
+        wrapped_agent_create = cls(
+            item=item,
+        )
+
+        wrapped_agent_create.additional_properties = d
+        return wrapped_agent_create
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/dart/generated/models/wrapped_agent_update.py
+++ b/dart/generated/models/wrapped_agent_update.py
@@ -1,0 +1,69 @@
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    TypeVar,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.agent_update import AgentUpdate
+
+
+T = TypeVar("T", bound="WrappedAgentUpdate")
+
+
+@_attrs_define
+class WrappedAgentUpdate:
+    """
+    Attributes:
+        item (AgentUpdate):
+    """
+
+    item: "AgentUpdate"
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        item = self.item.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "item": item,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.agent_update import AgentUpdate
+
+        d = dict(src_dict)
+        item = AgentUpdate.from_dict(d.pop("item"))
+
+        wrapped_agent_update = cls(
+            item=item,
+        )
+
+        wrapped_agent_update.additional_properties = d
+        return wrapped_agent_update
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/dart/generated/models/wrapped_skill_create.py
+++ b/dart/generated/models/wrapped_skill_create.py
@@ -1,0 +1,69 @@
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    TypeVar,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.skill_create import SkillCreate
+
+
+T = TypeVar("T", bound="WrappedSkillCreate")
+
+
+@_attrs_define
+class WrappedSkillCreate:
+    """
+    Attributes:
+        item (SkillCreate):
+    """
+
+    item: "SkillCreate"
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        item = self.item.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "item": item,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.skill_create import SkillCreate
+
+        d = dict(src_dict)
+        item = SkillCreate.from_dict(d.pop("item"))
+
+        wrapped_skill_create = cls(
+            item=item,
+        )
+
+        wrapped_skill_create.additional_properties = d
+        return wrapped_skill_create
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/dart/generated/models/wrapped_skill_update.py
+++ b/dart/generated/models/wrapped_skill_update.py
@@ -1,0 +1,69 @@
+from collections.abc import Mapping
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    TypeVar,
+)
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.skill_update import SkillUpdate
+
+
+T = TypeVar("T", bound="WrappedSkillUpdate")
+
+
+@_attrs_define
+class WrappedSkillUpdate:
+    """
+    Attributes:
+        item (SkillUpdate):
+    """
+
+    item: "SkillUpdate"
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        item = self.item.to_dict()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "item": item,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.skill_update import SkillUpdate
+
+        d = dict(src_dict)
+        item = SkillUpdate.from_dict(d.pop("item"))
+
+        wrapped_skill_update = cls(
+            item=item,
+        )
+
+        wrapped_skill_update.additional_properties = d
+        return wrapped_skill_update
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dart-tools"
-version = "0.8.12"
+version = "0.8.13"
 description = "The Dart CLI and Python Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -137,7 +137,7 @@ wheels = [
 
 [[package]]
 name = "dart-tools"
-version = "0.8.12"
+version = "0.8.13"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Add full CRUD API support for agents and skills

Introduces complete create, read, update, and delete endpoint functions for both agents and skills, alongside the corresponding request/response models (`AgentCreate`, `AgentUpdate`, `WrappedAgent`, `WrappedAgentCreate`, `WrappedAgentUpdate`, `SkillCreate`, `SkillUpdate`, `WrappedSkillCreate`, `WrappedSkillUpdate`) and paginated list types (`PaginatedAgentList`, `PaginatedSkillList`).

Agents are AI assistants that can be assigned tasks with customizable markdown instructions. Skills are workspace-wide user-defined instruction templates for specific task types. Both resources now support listing with pagination, retrieval by ID, creation, update (partial, by ID), and deletion.

The `skill` API module is also expanded beyond the previously available `retrieve_skill_by_title` to expose the full set of CRUD operations.