### PR TITLE
Fix codex response formatting

### DIFF
--- a/dart/agent.py
+++ b/dart/agent.py
@@ -355,6 +355,8 @@ class _LocalAgent:
             "item.subtype",
             "data.type",
             "data.subtype",
+            "msg.type",
+            "msg.subtype",
         )
         value_types = " ".join(
             value_type for path in value_type_paths if (value_type := _nested_string(value, path))
@@ -363,7 +365,17 @@ class _LocalAgent:
         if "thinking" in value_types or "reasoning" in value_types:
             detail = _first_string_from_paths(
                 value,
-                ("detail", "text", "content", "message", "item.detail", "item.text", "item.content", "data.content"),
+                (
+                    "detail",
+                    "text",
+                    "content",
+                    "message",
+                    "item.detail",
+                    "item.text",
+                    "item.content",
+                    "data.content",
+                    "msg.text",
+                ),
             )
             if detail:
                 event: dict[str, Any] = {_KIND_KEY: _THINKING_EVENT_KIND, "detail": detail}
@@ -624,7 +636,7 @@ _LOCAL_AGENTS: dict[str, _LocalAgent] = {
         ),
         install_command=_npm_install_command("@openai/codex"),
         session_id_key="thread_id",
-        response_key="item.text",
+        response_key=("item.text", "msg.message"),
         output_mode="jsonl",
         failure_response_keys=("error.message",),
         resume_command=(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dart-tools"
-version = "0.11.1"
+version = "0.11.2"
 description = "The Dart CLI and Python Library"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -137,7 +137,7 @@ wheels = [
 
 [[package]]
 name = "dart-tools"
-version = "0.11.1"
+version = "0.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Improves compatibility with the OpenAI Codex agent by adding support for `msg`-prefixed paths when parsing streamed JSONL output. The `msg.type` and `msg.subtype` fields are now recognized when identifying thinking/reasoning events, and `msg.text` is included as a fallback when extracting detail from those events. Additionally, `msg.message` is added as a fallback response key alongside `item.text` to handle alternate response shapes emitted by the Codex CLI.